### PR TITLE
Fix local failover example deploy, demo image and demo targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ deploy-first-k8gb: HELM_ARGS = --set k8gb.hostAlias.enabled=true --set k8gb.host
 deploy-first-k8gb: deploy-gslb-operator deploy-local-ingress
 
 .PHONY: deploy-second-k8gb
-deploy-second-k8gb: HELM_ARGS = --set k8gb.hostAlias.enabled=true --set k8gb.clusterGeoTag="us" --set k8gb.extGslbClustersGeoTags="eu" --set k8gb.hostAlias.hostname="test-gslb-ns-eu.example.com" --set k8gb.hostAlias.ip="$(HOST_ALIAS_IP2)" --set k8gb.imageRepo=$(K8GB_IMAGE_REPO)
+deploy-second-k8gb: HELM_ARGS = --set k8gb.hostAlias.enabled=true --set k8gb.clusterGeoTag="us" --set k8gb.extGslbClustersGeoTags="eu" --set k8gb.hostAlias.hostnames="{test-gslb-ns-eu.example.com,test-gslb-failover-ns-eu.example.com}" --set k8gb.hostAlias.ip="$(HOST_ALIAS_IP2)" --set k8gb.imageRepo=$(K8GB_IMAGE_REPO)
 deploy-second-k8gb: deploy-gslb-operator deploy-local-ingress
 
 .PHONY: deploy-full-local-setup

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,14 @@ test-round-robin:
 test-failover:
 	@$(call hit-testapp-host, "failover.cloud.example.com")
 
+.PHONY: demo-roundrobin
+demo-roundrobin:
+	@$(call demo-host, "app3.cloud.example.com")
+
+.PHONY: demo-failover
+demo-failover:
+	@$(call demo-host, "failover.cloud.example.com")
+
 .PHONY: version
 version:
 	@echo $(VERSION)
@@ -195,6 +203,11 @@ define hit-testapp-host
 	kubectl run -it --rm busybox --restart=Never --image=busybox -- sh -c \
 	"echo 'nameserver `$(K8GB_COREDNS_IP)`' > /etc/resolv.conf && \
 	wget -qO - $1"
+endef
+
+define demo-host
+	kubectl run -it --rm k8gbdemo --restart=Never --image=absaoss/k8gbdemocurl  \
+	"`$(K8GB_COREDNS_IP)`" $1
 endef
 
 define init-test-strategy

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -19,7 +19,9 @@ spec:
       hostAliases:
         - ip: "{{ .Values.k8gb.hostAlias.ip }}"
           hostnames:
-          - "{{ .Values.k8gb.hostAlias.hostname }}"
+            {{- range.Values.k8gb.hostAlias.hostnames }}
+            - {{ . }}
+            {{- end }}
       {{ end }}
       serviceAccountName: k8gb
       containers:

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -16,7 +16,9 @@ k8gb:
   hostAlias: # use https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ inside operator pod. Useful for advanced testing scenarios and to break dependency on EdgeDNS for cross k8gb collaboration
     enabled: false
     ip: "172.17.0.1"
-    hostname: "test-gslb-ns-us.example.com"
+    hostnames:
+     - "test-gslb-ns-us.example.com"
+     - "test-gslb-failover-ns-us.example.com"
   reconcileRequeueSeconds: 30
 
 externaldns:

--- a/deploy/test-apps/curldemo/Dockerfile
+++ b/deploy/test-apps/curldemo/Dockerfile
@@ -1,0 +1,7 @@
+FROM curlimages/curl:7.71.1
+
+COPY k8gbcurl.sh /k8gbcurl.sh
+
+USER root
+
+ENTRYPOINT ["/k8gbcurl.sh"]

--- a/deploy/test-apps/curldemo/k8gbcurl.sh
+++ b/deploy/test-apps/curldemo/k8gbcurl.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Small script to continously poll demo podinfo fqdn to show k8gb in action
+# $1 - nameserver to use usually k8gb-coredns service ip
+# $2 - test fqdn to resolve in demo loops
+
+echo "nameserver $1" > /etc/resolv.conf
+while true
+do
+  curl -s -w "%{stderr}\n%{http_code}\n" --location --request GET "$2" |grep message
+  sleep 5
+  echo "[`date`] ..."
+done


### PR DESCRIPTION
* extend hostAlias.hostnames to be a list
* Adapt template and Makefile to cover failover
  sample CR and enable local end-to-end testing
  for failover strategy
* Demo image with looping curl and demo targets
 `make demo-failover`
    or
    `make demo-roundrobin`
    and we are ready to demo