### PR TITLE
Mitigate coredns etcd plugin bug

### DIFF
--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.3
+version: 0.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.6.3
+appVersion: 0.6.4
 
 dependencies:
   - name: coredns

--- a/pkg/controller/gslb/fakedns.go
+++ b/pkg/controller/gslb/fakedns.go
@@ -19,7 +19,7 @@ func oldEdgeTimestamp(threshold string) string {
 }
 
 var records = map[string][]string{
-	"localtargets.app3.cloud.example.com.": []string{"10.1.0.1", "10.1.0.2", "10.1.0.3"},
+	"localtargets-app3.cloud.example.com.": []string{"10.1.0.1", "10.1.0.2", "10.1.0.3"},
 	"test-gslb-heartbeat-eu.example.com.":  []string{oldEdgeTimestamp("10m")},
 	"test-gslb-heartbeat-za.example.com.":  []string{oldEdgeTimestamp("3m")},
 }

--- a/pkg/controller/gslb/gslb_controller_test.go
+++ b/pkg/controller/gslb/gslb_controller_test.go
@@ -300,7 +300,7 @@ func TestGslbController(t *testing.T) {
 
 		want := []*externaldns.Endpoint{
 			{
-				DNSName:    "localtargets.app3.cloud.example.com",
+				DNSName:    "localtargets-app3.cloud.example.com",
 				RecordTTL:  30,
 				RecordType: "A",
 				Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"}},
@@ -386,7 +386,7 @@ func TestGslbController(t *testing.T) {
 
 		want := []*externaldns.Endpoint{
 			{
-				DNSName:    "localtargets.app3.cloud.example.com",
+				DNSName:    "localtargets-app3.cloud.example.com",
 				RecordTTL:  30,
 				RecordType: "A",
 				Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"}},
@@ -515,7 +515,7 @@ func TestGslbController(t *testing.T) {
 
 		want := []*externaldns.Endpoint{
 			{
-				DNSName:    "localtargets.app3.cloud.example.com",
+				DNSName:    "localtargets-app3.cloud.example.com",
 				RecordTTL:  30,
 				RecordType: "A",
 				Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
@@ -576,7 +576,7 @@ func TestGslbController(t *testing.T) {
 
 		want := []*externaldns.Endpoint{
 			{
-				DNSName:    "localtargets.app3.cloud.example.com",
+				DNSName:    "localtargets-app3.cloud.example.com",
 				RecordTTL:  30,
 				RecordType: "A",
 				Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"},


### PR DESCRIPTION
* Mitigate https://github.com/coredns/coredns/issues/3803
* Switch to separated fqdn schema like `localtargets-app.cloud.example.com` instead
  of old `localtargets.app.cloud.example.com`
* Looks less neat still fully workarounds upstream bug
* Enhanced logging around Failover strategy decision making
  and Final target list compostion
* Image and Chart versions bump