### PR TITLE
Add ability to override k8gb image tag

### DIFF
--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: k8gb
       containers:
         - name: k8gb
-          image: {{ .Values.k8gb.imageRepo }}:v{{ .Chart.AppVersion }}
+          image: {{ .Values.k8gb.imageRepo }}:v{{ .Values.k8gb.imageTag | default .Chart.AppVersion }}
           command:
           - k8gb
           imagePullPolicy: Always
@@ -80,4 +80,3 @@ spec:
                   name: external-dns
                   key: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
             {{ end }}
-


### PR DESCRIPTION
- Adds possibility to override `k8gb` image tag by `Values.k8gb.imageTag`.
- `Chart.AppVersion` is used as default value