### PR TITLE
Initial configuration layout for Route53 support

### DIFF
--- a/chart/k8gb/templates/coredns-svc-aws.yaml
+++ b/chart/k8gb/templates/coredns-svc-aws.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.route53.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  name: k8gb-coredns-lb
+  namespace: k8gb
+spec:
+  ports:
+  - name: udp-53
+    port: 53
+    protocol: UDP
+  selector:
+    app.kubernetes.io/instance: k8gb
+    app.kubernetes.io/name: coredns
+  type: LoadBalancer
+{{ end }}

--- a/chart/k8gb/templates/external-dns/external-dns-route53.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns-route53.yaml
@@ -1,0 +1,41 @@
+{{ if .Values.route53.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  # If you're using Amazon EKS with IAM Roles for Service Accounts, specify the following annotation.
+  # Otherwise, you may safely omit it.
+  annotations:
+    # Substitute your account ID and IAM service role name below.
+    eks.amazonaws.com/role-arn: {{ .Values.route53.irsaRole }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns-route53
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns-route53
+  template:
+    metadata:
+      labels:
+        app: external-dns-route53
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: {{ .Values.externaldns.image }}
+        args:
+        - --source=crd
+        - --domain-filter={{ .Values.route53.domain }} # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
+        - --annotation-filter=k8gb.absa.oss/dnstype=route53 # filter out only relevant DNSEntrypoints
+        - --provider=aws
+        - --aws-zone-type=public # only look at public hosted zones (valid values are public, private or no value for both)
+        - --registry=txt
+        - --txt-owner-id= {{ .Values.route53.hostedZoneID }}
+      securityContext:
+        fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
+{{ end }}

--- a/chart/k8gb/templates/ingress/udp-services.yaml
+++ b/chart/k8gb/templates/ingress/udp-services.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.externaldns.expose53onWorkers }}
 apiVersion: v1
 data:
   "53": k8gb/k8gb-coredns:53
@@ -5,3 +6,4 @@ kind: ConfigMap
 metadata:
   name: udp-services
   namespace: {{ .Values.k8gb.ingressNamespace }}
+{{ end }}

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -78,3 +78,7 @@ spec:
                   name: external-dns
                   key: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
             {{ end }}
+            {{ if .Values.route53.enabled }}
+            - name: ROUTE53_ENABLED
+              value: "true"
+            {{ end }}

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -24,6 +24,7 @@ k8gb:
 externaldns:
   image: k8s.gcr.io/external-dns/external-dns:v0.7.4
   interval: "20s"
+  expose53onWorkers: true # open 53/udp on workers nodes with nginx controller
 
 etcd-operator:
   customResources:

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -22,7 +22,7 @@ k8gb:
   reconcileRequeueSeconds: 30
 
 externaldns:
-  image: eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.2
+  image: k8s.gcr.io/external-dns/external-dns:v0.7.4
   interval: "20s"
 
 etcd-operator:
@@ -87,3 +87,9 @@ infoblox:
   wapiVersion: 2.3.1
   wapiPort: 443
   sslVerify: true
+
+route53:
+  enabled: false
+  hostedZoneID: ZXXXSSS
+  domain: cloud.example.com
+  irsaRole: arn:aws:iam::111111:role/external-dns

--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -20,6 +20,8 @@ type Config struct {
 	ReconcileRequeueSeconds int
 	// Cluster Geo Tag to determine specific location
 	ClusterGeoTag string
+	// Route53 switch
+	Route53Enabled bool
 }
 
 //DependencyResolver resolves configuration for GSLB

--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -10,6 +10,7 @@ import (
 const (
 	reconcileRequeueSecondsKey = "RECONCILE_REQUEUE_SECONDS"
 	clusterGeoTagKey           = "CLUSTER_GEO_TAG"
+	route53EnabledKey          = "ROUTE53_ENABLED"
 )
 
 // ResolveOperatorConfig executes once. It reads operator's configuration
@@ -20,6 +21,7 @@ func (dr *DependencyResolver) ResolveOperatorConfig() (*Config, error) {
 		// set predefined values when not read from the environment variables
 		dr.config.ReconcileRequeueSeconds, _ = env.GetEnvAsIntOrFallback(reconcileRequeueSecondsKey, 30)
 		dr.config.ClusterGeoTag = env.GetEnvAsStringOrFallback(clusterGeoTagKey, "unset")
+		dr.config.Route53Enabled = env.GetEnvAsBoolOrFallback(route53EnabledKey, false)
 		dr.errorConfig = dr.validateConfig(dr.config)
 	})
 	return dr.config, dr.errorConfig

--- a/controllers/dnsupdate.go
+++ b/controllers/dnsupdate.go
@@ -378,6 +378,9 @@ func filterOutDelegateTo(delegateTo []ibclient.NameServer, fqdn string) []ibclie
 func (r *GslbReconciler) configureZoneDelegation(gslb *k8gbv1beta1.Gslb) (*reconcile.Result, error) {
 	clusterGeoTag := os.Getenv("CLUSTER_GEO_TAG")
 	infobloxGridHost := os.Getenv("INFOBLOX_GRID_HOST")
+	if r.Config.Route53Enabled {
+		log.Info("Gonna rule route53")
+	}
 	if len(infobloxGridHost) > 0 {
 
 		objMgr, err := infobloxConnection()

--- a/controllers/dnsupdate.go
+++ b/controllers/dnsupdate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -397,6 +398,7 @@ func (r *GslbReconciler) configureZoneDelegation(gslb *k8gbv1beta1.Gslb) (*recon
 		var NSServerList []string
 		NSServerList = append(NSServerList, nsServerName(gslb, clusterGeoTag))
 		NSServerList = append(NSServerList, nsServerNameExt(gslb, extClusterGeoTags)...)
+		sort.Strings(NSServerList)
 		NSRecord := &externaldns.DNSEndpoint{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        fmt.Sprintf("%s-route53", gslb.Name),

--- a/controllers/dnsupdate.go
+++ b/controllers/dnsupdate.go
@@ -409,14 +409,15 @@ func (r *GslbReconciler) configureZoneDelegation(gslb *k8gbv1beta1.Gslb) (*recon
 						DNSName:    gslbZoneName,
 						RecordTTL:  ttl,
 						RecordType: "NS",
-						Targets: externaldns.Targets{
-							nsServerName(gslb, clusterGeoTag),
-						},
+						Targets:    NSServerList,
 					},
 				},
 			},
 		}
-		r.ensureDNSEndpoint(gslb, NSRecord)
+		res, err := r.ensureDNSEndpoint(gslb, NSRecord)
+		if err != nil {
+			return res, err
+		}
 	}
 	if len(infobloxGridHost) > 0 {
 

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -135,7 +135,6 @@ func (r *GslbReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	result, err = r.ensureDNSEndpoint(
-		req,
 		gslb,
 		dnsEndpoint)
 	if result != nil {

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -734,8 +734,8 @@ func TestGslbController(t *testing.T) {
 				RecordType: "NS",
 				Targets: externaldns.Targets{
 					"test-gslb-ns-eu.example.com",
+					"test-gslb-ns-us.example.com",
 					"test-gslb-ns-za.example.com",
-					"test-gslb-ns-eu.example.com",
 				},
 			},
 		}
@@ -743,7 +743,7 @@ func TestGslbController(t *testing.T) {
 		prettyGot := prettyPrint(gotEp)
 		prettyWant := prettyPrint(wantEp)
 
-		if !reflect.DeepEqual(got, want) {
+		if !reflect.DeepEqual(gotEp, wantEp) {
 			t.Errorf("got:\n %s DNSEndpoint,\n\n want:\n %s", prettyGot, prettyWant)
 		}
 	})

--- a/controllers/internal/env/env.go
+++ b/controllers/internal/env/env.go
@@ -55,3 +55,16 @@ func GetEnvAsFloat64OrFallback(key string, defaultValue float64) (float64, error
 	}
 	return defaultValue, nil
 }
+
+// GetEnvAsBoolOrFallback returns the env variable for the given key,
+// parses it as boolean and falls back to the given defaultValue if not set
+func GetEnvAsBoolOrFallback(key string, defaultValue bool) bool {
+	if v := os.Getenv(key); v != "" {
+		val, err := strconv.ParseBool(v)
+		if err != nil {
+			return defaultValue
+		}
+		return val
+	}
+	return defaultValue
+}


### PR DESCRIPTION
It's not yet working solution but important foundation for further full support.

* Separate `external-dns-route53` deployment which exclusively handles route53 updates
* CoreDNS service type LoadBalancer which exposes 53/udp with Network Load Balancer without the need of special upd config of Nginx Ingress controller also avoiding 53/udp exposure on each of the worker nodes as in on-prem scenario
* K8gb configuration options for route53 enablement and associated depresolver modifications
* Helper makefile targets to ease the testing of temporary k8gb images in AWS
* Creation of DNSEndpoint CRD with NS record as a start of automated Zone delegation configuration in Route53
* Associated tests

Unfortunately external-dns currently does not pick up NS records which are described as CRD.

We will have to fix https://github.com/kubernetes-sigs/external-dns/issues/1647 upstream to proceed further with the implementation