### PR TITLE
gosec; ignore generated code

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -11,6 +11,6 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v2
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.2.0
+        uses: securego/gosec@master
         with:
-          args: ./...
+          args: -exclude-dir=v1beta1 ./...


### PR DESCRIPTION
Related to (#115) and (#114).

I'm ignoring generated code within `v1beta1`
```
[/github/workspace/pkg/apis/ohmyglb/v1beta1/zz_generated.deepcopy.go:113] - G601 (CWE-): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
  > &val


Summary:
   Files: 20
   Lines: 1969
   Nosec: 0
  Issues: 1

```