### PR TITLE
Simplify values.yaml

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -8,9 +8,9 @@ global:
 k8gb:
   imageRepo: absaoss/k8gb # image tag is defined in Chart.AppVersion, see Chart.yaml
   ingressNamespace: "k8gb"
-  dnsZone: &dnsZone "cloud.example.com" # dnsZone controlled by gslb
-  edgeDNSZone: &edgeDNSZone "example.com" # main zone which would contain gslb zone to delegate
-  edgeDNSServer: &edgeDNSServer "1.1.1.1" # to handle splitbrain situation with TXT timestamp
+  dnsZone: "cloud.example.com" # dnsZone controlled by gslb
+  edgeDNSZone: "example.com" # main zone which would contain gslb zone to delegate
+  edgeDNSServer: "1.1.1.1" # to handle splitbrain situation with TXT timestamp
   clusterGeoTag: "eu" # used for places where we need to distinguish between differnet Gslb instances
   extGslbClustersGeoTags: "us" # comma-separated list of external gslb geo tags to pair with
   hostAlias: # use https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ inside operator pod. Useful for advanced testing scenarios and to break dependency on EdgeDNS for cross k8gb collaboration
@@ -75,7 +75,7 @@ coredns:
     - name: forward
       parameters: . /etc/resolv.conf
     - name: etcd
-      parameters: *dnsZone
+      parameters: .
       configBlock: |-
         stubzones
         path /skydns


### PR DESCRIPTION
* Get rid of anchors
* No need to explicitly specify gslb dnsZone
  in coredns etcd plugin config - we can just serve the dot
* It breaks the anchoring dependency in values yaml and
  enables more simple values override on consumer side