### PR TITLE
Extend with fake environment variables

### DIFF
--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -40,6 +40,14 @@ type Infoblox struct {
 	Password string
 }
 
+// Override configuration
+type Override struct {
+	// FakeDNSEnabled; default=false
+	FakeDNSEnabled bool
+	// FakeInfobloxEnabled if true than Infoblox connection FQDN=`fakezone.example.com`; default = false
+	FakeInfobloxEnabled bool
+}
+
 // Config is operator configuration returned by depResolver
 type Config struct {
 	// Reschedule of Reconcile loop to pickup external Gslb targets
@@ -61,6 +69,8 @@ type Config struct {
 	Route53Enabled bool
 	// Infoblox configuration
 	Infoblox Infoblox
+	// Override the behavior of GSLB in the test environments
+	Override Override
 }
 
 // DependencyResolver resolves configuration for GSLB

--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -20,11 +20,9 @@ const (
 	InfobloxPortKey            = "INFOBLOX_WAPI_PORT"
 	InfobloxUsernameKey        = "EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME"
 	// #nosec G101; ignore false positive gosec; see: https://securego.io/docs/rules/g101.html
-	InfobloxPasswordKey = "EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD"
-	// TODO: resolve, validations, tests
-	OverrideWithFakeDNSKey = "OVERRIDE_WITH_FAKE_EXT_DNS"
-	// TODO: resolve, validations, tests
-	FakeInfoblox = "FAKE_INFOBLOX"
+	InfobloxPasswordKey     = "EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD"
+	OverrideWithFakeDNSKey  = "OVERRIDE_WITH_FAKE_EXT_DNS"
+	OverrideFakeInfobloxKey = "FAKE_INFOBLOX"
 )
 
 // ResolveOperatorConfig executes once. It reads operator's configuration
@@ -44,6 +42,8 @@ func (dr *DependencyResolver) ResolveOperatorConfig() (*Config, error) {
 		dr.config.Infoblox.Port, _ = env.GetEnvAsIntOrFallback(InfobloxPortKey, 0)
 		dr.config.Infoblox.Username = env.GetEnvAsStringOrFallback(InfobloxUsernameKey, "")
 		dr.config.Infoblox.Password = env.GetEnvAsStringOrFallback(InfobloxPasswordKey, "")
+		dr.config.Override.FakeDNSEnabled = env.GetEnvAsBoolOrFallback(OverrideWithFakeDNSKey, false)
+		dr.config.Override.FakeInfobloxEnabled = env.GetEnvAsBoolOrFallback(OverrideFakeInfobloxKey, false)
 		dr.errorConfig = dr.validateConfig(dr.config)
 		dr.config.EdgeDNSType = getEdgeDNSType(dr.config)
 	})


### PR DESCRIPTION
related to #170, In order to missing fake variables in depresolver I had to extend with:
 
- OVERRIDE_WITH_FAKE_EXT_DNS
 - FAKE_INFOBLOX

cover by tests, update controller_tests
