### PR TITLE
Zone delegation garbage collection for Route53

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 all: manager
 
 # Run tests
-test: generate fmt vet manifests
+test: lint generate fmt vet manifests
 	go test ./... -coverprofile cover.out
 
 # Build manager binary

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.7
+version: 0.6.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.6.7
+appVersion: 0.6.8
 
 dependencies:
   - name: coredns

--- a/chart/k8gb/templates/external-dns/external-dns-route53.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns-route53.yaml
@@ -23,8 +23,8 @@ spec:
         - --domain-filter={{ .Values.k8gb.edgeDNSZone }} # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
         - --annotation-filter=k8gb.absa.oss/dnstype=route53 # filter out only relevant DNSEntrypoints
         - --provider=aws
-        - --txt-owner-id= {{ .Values.route53.hostedZoneID }}
-        - --policy=upsert-only # would prevent ExternalDNS from deleting any records, critical for k8gb, otherwise multiple k8gb instances will try to delete each other records in the same zone
+        - --txt-owner-id=k8gb-{{ .Values.route53.hostedZoneID }}-{{ .Values.k8gb.clusterGeoTag }}
+        - --policy=sync # enable full synchronization including record removal
         - --log-level=debug # debug only
       securityContext:
         fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files

--- a/controllers/dnsupdate.go
+++ b/controllers/dnsupdate.go
@@ -429,7 +429,7 @@ func (r *GslbReconciler) coreDNSExposedIPs() ([]string, error) {
 	err := r.Get(context.TODO(), types.NamespacedName{Namespace: k8gbNamespace, Name: coreDNSServiceName}, coreDNSService)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			log.Info("Can't find %s service", coreDNSServiceName)
+			log.Info(fmt.Sprintf("Can't find %s service", coreDNSServiceName))
 		}
 		return nil, err
 	}


### PR DESCRIPTION
* Remove Zone delegation config during Gslb finalization process
* Switch external dns to sync mode and use different geo based
  ownership tags per k8gb instance
* Associated tests
* Logging bugfix inline
* Include linting as dependency to standard test make target
* Minor version bump