### PR TITLE
Include GSLB dns zone into NS server names

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -17,7 +17,7 @@ k8gb:
     enabled: false
     ip: "172.17.0.1"
     hostnames:
-     - "gslb-ns-us.example.com"
+     - "gslb-ns-cloud-example-com-us.example.com"
   reconcileRequeueSeconds: 30
 
 externaldns:

--- a/controllers/dnsupdate.go
+++ b/controllers/dnsupdate.go
@@ -59,24 +59,6 @@ func (r *GslbReconciler) getGslbIngressIPs(gslb *k8gbv1beta1.Gslb) ([]string, er
 	return gslbIngressIPs, nil
 }
 
-func getExternalClusterFQDNs(gslb *k8gbv1beta1.Gslb) []string {
-	extGslbClustersGeoTagsVar := os.Getenv("EXT_GSLB_CLUSTERS_GEO_TAGS")
-
-	if extGslbClustersGeoTagsVar == "" {
-		log.Info("No other Gslb enabled clusters are defined in the configuration...Working standalone")
-		return nil
-	}
-
-	extGslbClustersGeoTags := strings.Split(extGslbClustersGeoTagsVar, ",")
-
-	var extGslbClusters []string
-	for _, geoTag := range extGslbClustersGeoTags {
-		cluster := nsServerName(gslb, geoTag)
-		extGslbClusters = append(extGslbClusters, cluster)
-	}
-	return extGslbClusters
-}
-
 func getExternalClusterHeartbeatFQDNs(gslb *k8gbv1beta1.Gslb) []string {
 	extGslbClustersGeoTagsVar := os.Getenv("EXT_GSLB_CLUSTERS_GEO_TAGS")
 
@@ -95,9 +77,9 @@ func getExternalClusterHeartbeatFQDNs(gslb *k8gbv1beta1.Gslb) []string {
 	return extGslbClusters
 }
 
-func getExternalTargets(gslb *k8gbv1beta1.Gslb, host string) ([]string, error) {
+func (r *GslbReconciler) getExternalTargets(gslb *k8gbv1beta1.Gslb, host string) ([]string, error) {
 
-	extGslbClusters := getExternalClusterFQDNs(gslb)
+	extGslbClusters := r.nsServerNameExt(gslb)
 
 	var targets []string
 
@@ -173,7 +155,7 @@ func (r *GslbReconciler) gslbDNSEndpoint(gslb *k8gbv1beta1.Gslb) (*externaldns.D
 		}
 
 		// Check if host is alive on external Gslb
-		externalTargets, err := getExternalTargets(gslb, host)
+		externalTargets, err := r.getExternalTargets(gslb, host)
 		if err != nil {
 			return nil, err
 		}
@@ -237,20 +219,24 @@ func (r *GslbReconciler) gslbDNSEndpoint(gslb *k8gbv1beta1.Gslb) (*externaldns.D
 	return dnsEndpoint, err
 }
 
-func nsServerName(gslb *k8gbv1beta1.Gslb, clusterGeoTag string) string {
-	edgeDNSZone := os.Getenv("EDGE_DNS_ZONE")
-	if len(clusterGeoTag) == 0 {
-		clusterGeoTag = "default"
-	}
-	return fmt.Sprintf("gslb-ns-%s.%s", clusterGeoTag, edgeDNSZone)
+func (r *GslbReconciler) nsServerName(gslb *k8gbv1beta1.Gslb) string {
+	dnsZoneIntoNS := strings.ReplaceAll(r.Config.DNSZone, ".", "-")
+	return fmt.Sprintf("gslb-ns-%s-%s.%s",
+		dnsZoneIntoNS,
+		r.Config.ClusterGeoTag,
+		r.Config.EdgeDNSZone)
 }
 
-func nsServerNameExt(gslb *k8gbv1beta1.Gslb, extClusterGeoTags string) []string {
-	edgeDNSZone := os.Getenv("EDGE_DNS_ZONE")
+func (r *GslbReconciler) nsServerNameExt(gslb *k8gbv1beta1.Gslb) []string {
 
+	dnsZoneIntoNS := strings.ReplaceAll(r.Config.DNSZone, ".", "-")
 	var extNSServers []string
-	for _, clusterGeoTag := range strings.Split(extClusterGeoTags, ",") {
-		extNSServers = append(extNSServers, fmt.Sprintf("gslb-ns-%s.%s", clusterGeoTag, edgeDNSZone))
+	for _, clusterGeoTag := range r.Config.ExtClustersGeoTags {
+		extNSServers = append(extNSServers,
+			fmt.Sprintf("gslb-ns-%s-%s.%s",
+				dnsZoneIntoNS,
+				clusterGeoTag,
+				r.Config.EdgeDNSZone))
 	}
 
 	return extNSServers
@@ -451,17 +437,14 @@ func (r *GslbReconciler) coreDNSExposedIPs() ([]string, error) {
 }
 
 func (r *GslbReconciler) configureZoneDelegation(gslb *k8gbv1beta1.Gslb) (*reconcile.Result, error) {
-	clusterGeoTag := os.Getenv("CLUSTER_GEO_TAG")
-	extClusterGeoTags := os.Getenv("EXT_GSLB_CLUSTERS_GEO_TAGS")
-	infobloxGridHost := os.Getenv("INFOBLOX_GRID_HOST")
 	// TODO: Rute53Enabled private, use `r.Config.EdgeDNSType==depresolver.Route53` instead.
 	if r.Config.Route53Enabled {
 		ttl := externaldns.TTL(gslb.Spec.Strategy.DNSTtlSeconds)
 		gslbZoneName := os.Getenv("DNS_ZONE")
 		log.Info("Creating/Updating DNSEndpoint CRDs for Route53...")
 		var NSServerList []string
-		NSServerList = append(NSServerList, nsServerName(gslb, clusterGeoTag))
-		NSServerList = append(NSServerList, nsServerNameExt(gslb, extClusterGeoTags)...)
+		NSServerList = append(NSServerList, r.nsServerName(gslb))
+		NSServerList = append(NSServerList, r.nsServerNameExt(gslb)...)
 		sort.Strings(NSServerList)
 		NSServerIPs, err := r.coreDNSExposedIPs()
 		if err != nil {
@@ -482,7 +465,7 @@ func (r *GslbReconciler) configureZoneDelegation(gslb *k8gbv1beta1.Gslb) (*recon
 						Targets:    NSServerList,
 					},
 					{
-						DNSName:    nsServerName(gslb, clusterGeoTag),
+						DNSName:    r.nsServerName(gslb),
 						RecordTTL:  ttl,
 						RecordType: "A",
 						Targets:    NSServerIPs,
@@ -495,7 +478,7 @@ func (r *GslbReconciler) configureZoneDelegation(gslb *k8gbv1beta1.Gslb) (*recon
 			return res, err
 		}
 	}
-	if len(infobloxGridHost) > 0 {
+	if len(r.Config.Infoblox.Host) > 0 {
 
 		objMgr, err := infobloxConnection()
 		if err != nil {
@@ -508,12 +491,11 @@ func (r *GslbReconciler) configureZoneDelegation(gslb *k8gbv1beta1.Gslb) (*recon
 		delegateTo := []ibclient.NameServer{}
 
 		for _, address := range addresses {
-			nameServer := ibclient.NameServer{Address: address, Name: nsServerName(gslb, clusterGeoTag)}
+			nameServer := ibclient.NameServer{Address: address, Name: r.nsServerName(gslb)}
 			delegateTo = append(delegateTo, nameServer)
 		}
 
 		gslbZoneName := os.Getenv("DNS_ZONE")
-		edgeDNSZone := os.Getenv("EDGE_DNS_ZONE")
 		edgeDNSServer := os.Getenv("EDGE_DNS_SERVER")
 		findZone, err := objMgr.GetZoneDelegated(gslbZoneName)
 		if err != nil {
@@ -528,7 +510,7 @@ func (r *GslbReconciler) configureZoneDelegation(gslb *k8gbv1beta1.Gslb) (*recon
 			if len(findZone.Ref) > 0 {
 
 				// Drop own records for straight away update
-				existingDelegateTo := filterOutDelegateTo(findZone.DelegateTo, nsServerName(gslb, clusterGeoTag))
+				existingDelegateTo := filterOutDelegateTo(findZone.DelegateTo, r.nsServerName(gslb))
 				existingDelegateTo = append(existingDelegateTo, delegateTo...)
 
 				// Drop external records if they are stale
@@ -557,7 +539,7 @@ func (r *GslbReconciler) configureZoneDelegation(gslb *k8gbv1beta1.Gslb) (*recon
 		}
 
 		edgeTimestamp := fmt.Sprint(time.Now().UTC().Format("2006-01-02T15:04:05"))
-		heartbeatTXTName := fmt.Sprintf("%s-heartbeat-%s.%s", gslb.Name, clusterGeoTag, edgeDNSZone)
+		heartbeatTXTName := fmt.Sprintf("%s-heartbeat-%s.%s", gslb.Name, r.Config.ClusterGeoTag, r.Config.EdgeDNSZone)
 		heartbeatTXTRecord, err := objMgr.GetTXTRecord(heartbeatTXTName)
 		if err != nil {
 			return &reconcile.Result{}, err

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -350,7 +350,7 @@ func TestGeneratesProperExternalNSTargetFQDNsAccordingToTheGeoTags(t *testing.T)
 	customConfig.ExtClustersGeoTags = []string{"za"}
 	settings := provideSettings(t, customConfig)
 	// act
-	got := settings.reconciler.nsServerNameExt(settings.gslb)
+	got := settings.reconciler.nsServerNameExt()
 	// assert
 	assert.Equal(t, want, got, "got:\n %q externalGslb NS records,\n\n want:\n %q", got, want)
 }
@@ -439,7 +439,7 @@ func TestCanFilterOutDelegatedZoneEntryAccordingFQDNProvided(t *testing.T) {
 	customConfig.ExtClustersGeoTags = []string{"za"}
 	settings := provideSettings(t, customConfig)
 	// act
-	extClusters := settings.reconciler.nsServerNameExt(settings.gslb)
+	extClusters := settings.reconciler.nsServerNameExt()
 	got := filterOutDelegateTo(delegateTo, extClusters[0])
 	// assert
 	assert.Equal(t, want, got, "got:\n %q filtered out delegation records,\n\n want:\n %q", got, want)

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -344,13 +344,13 @@ func TestLocalDNSRecordsHasSpecialAnnotation(t *testing.T) {
 func TestGeneratesProperExternalNSTargetFQDNsAccordingToTheGeoTags(t *testing.T) {
 	// arrange
 	defer cleanup()
-	want := []string{"gslb-ns-za.example.com"}
+	want := []string{"gslb-ns-cloud-example-com-za.example.com"}
 	customConfig := predefinedConfig
 	customConfig.EdgeDNSZone = "example.com"
 	customConfig.ExtClustersGeoTags = []string{"za"}
 	settings := provideSettings(t, customConfig)
 	// act
-	got := getExternalClusterFQDNs(settings.gslb)
+	got := settings.reconciler.nsServerNameExt(settings.gslb)
 	// assert
 	assert.Equal(t, want, got, "got:\n %q externalGslb NS records,\n\n want:\n %q", got, want)
 }
@@ -422,24 +422,24 @@ func TestCanFilterOutDelegatedZoneEntryAccordingFQDNProvided(t *testing.T) {
 	// arrange
 	defer cleanup()
 	delegateTo := []ibclient.NameServer{
-		{Address: "10.0.0.1", Name: "gslb-ns-eu.example.com"},
-		{Address: "10.0.0.2", Name: "gslb-ns-eu.example.com"},
-		{Address: "10.0.0.3", Name: "gslb-ns-eu.example.com"},
-		{Address: "10.1.0.1", Name: "gslb-ns-za.example.com"},
-		{Address: "10.1.0.2", Name: "gslb-ns-za.example.com"},
-		{Address: "10.1.0.3", Name: "gslb-ns-za.example.com"},
+		{Address: "10.0.0.1", Name: "gslb-ns-cloud-example-com-eu.example.com"},
+		{Address: "10.0.0.2", Name: "gslb-ns-cloud-example-com-eu.example.com"},
+		{Address: "10.0.0.3", Name: "gslb-ns-cloud-example-com-eu.example.com"},
+		{Address: "10.1.0.1", Name: "gslb-ns-cloud-example-com-za.example.com"},
+		{Address: "10.1.0.2", Name: "gslb-ns-cloud-example-com-za.example.com"},
+		{Address: "10.1.0.3", Name: "gslb-ns-cloud-example-com-za.example.com"},
 	}
 	want := []ibclient.NameServer{
-		{Address: "10.0.0.1", Name: "gslb-ns-eu.example.com"},
-		{Address: "10.0.0.2", Name: "gslb-ns-eu.example.com"},
-		{Address: "10.0.0.3", Name: "gslb-ns-eu.example.com"},
+		{Address: "10.0.0.1", Name: "gslb-ns-cloud-example-com-eu.example.com"},
+		{Address: "10.0.0.2", Name: "gslb-ns-cloud-example-com-eu.example.com"},
+		{Address: "10.0.0.3", Name: "gslb-ns-cloud-example-com-eu.example.com"},
 	}
 	customConfig := predefinedConfig
 	customConfig.EdgeDNSZone = "example.com"
 	customConfig.ExtClustersGeoTags = []string{"za"}
 	settings := provideSettings(t, customConfig)
 	// act
-	extClusters := getExternalClusterFQDNs(settings.gslb)
+	extClusters := settings.reconciler.nsServerNameExt(settings.gslb)
 	got := filterOutDelegateTo(delegateTo, extClusters[0])
 	// assert
 	assert.Equal(t, want, got, "got:\n %q filtered out delegation records,\n\n want:\n %q", got, want)
@@ -655,13 +655,13 @@ func TestCreatesNSDNSRecordsForRoute53(t *testing.T) {
 			RecordTTL:  30,
 			RecordType: "NS",
 			Targets: externaldns.Targets{
-				"gslb-ns-eu.example.com",
-				"gslb-ns-us.example.com",
-				"gslb-ns-za.example.com",
+				"gslb-ns-cloud-example-com-eu.example.com",
+				"gslb-ns-cloud-example-com-us.example.com",
+				"gslb-ns-cloud-example-com-za.example.com",
 			},
 		},
 		{
-			DNSName:    "gslb-ns-eu.example.com",
+			DNSName:    "gslb-ns-cloud-example-com-eu.example.com",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets: externaldns.Targets{

--- a/docs/deploy_route53.md
+++ b/docs/deploy_route53.md
@@ -63,7 +63,7 @@ kubectl -n test-gslb get gslb test-gslb-failover -o yaml
 aws route53 list-resource-record-sets --hosted-zone-id $YOUR_HOSTED_ZONE_ID
 ```
 
-You should see that `gslb-ns-$geotag` NS and glue A records were created to
+You should see that `gslb-ns-$dnsZone-$geotag` NS and glue A records were created to
 automatically configure DNS zone delegation.
 
 * Check test application availability.


### PR DESCRIPTION
* Makes NS server FQDNs unique per k8gb cluster pair
* Without this change distinct k8gb cluster deployments
  which are responsible for different gslb DNS zones
  would clash with writing to the same NS records
  if operating in the same edgeDNSZone
* Switch from env vars to depresolver config on the way