### PR TITLE
Finalize Gslb if no route53 DNSEndpoint found

### DIFF
--- a/controllers/finalize.go
+++ b/controllers/finalize.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	k8gbv1beta1 "github.com/AbsaOSS/k8gb/api/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	externaldns "sigs.k8s.io/external-dns/endpoint"
 )
@@ -23,6 +24,10 @@ func (r *GslbReconciler) finalizeGslb(gslb *k8gbv1beta1.Gslb) error {
 		dnsEndpointRoute53 := &externaldns.DNSEndpoint{}
 		err := r.Get(context.Background(), client.ObjectKey{Namespace: k8gbNamespace, Name: "k8gb-ns-route53"}, dnsEndpointRoute53)
 		if err != nil {
+			if errors.IsNotFound(err) {
+				log.Info(fmt.Sprint(err))
+				return nil
+			}
 			return err
 		}
 		err = r.Delete(context.Background(), dnsEndpointRoute53)

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -792,7 +792,6 @@ func TestRoute53ZoneDelegationGarbageCollection(t *testing.T) {
 	dnsEndpointRoute53 := &externaldns.DNSEndpoint{}
 	err = settings.client.Get(context.TODO(), client.ObjectKey{Namespace: k8gbNamespace, Name: "k8gb-ns-route53"}, dnsEndpointRoute53)
 	require.Error(t, err, "k8gb-ns-route53 DNSEndpoint should be garbage collected")
-
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
* Don't return error if DNSEndpoint is already removed
* Unfortunately controller-runtime's fake client does not remove
  finalizer when it is actually removed in reality so no way
  to properly unit test it
* Terraform test for this seems to be an overkill