### PR TITLE
Fix Helm release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Install golang linting tools
+        run: |
+          go get github.com/kisielk/errcheck
+          go get honnef.co/go/tools/cmd/staticcheck
+          go get golang.org/x/lint/golint
       - name: Operator image build and push
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
@@ -34,4 +39,3 @@ jobs:
            helm repo add k8gb https://absaoss.github.io/k8gb/
            helm repo update
            helm -n k8gb upgrade -i k8gb k8gb/k8gb --wait --create-namespace --version=$(make version)
-


### PR DESCRIPTION
Recently I introduced linting as dependency
for test and docker build in Makefile.

It is very useful for local developer productivity,
unfortunately it broke the release pipe given linting
tools are not presented on github action runner.

Let's fix that to install them with `go get`