### PR TITLE
Fix contributing section rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ The first line is the subject and should be no longer than 70 characters, the se
 
 ## Documentation
 
-If the contribution changes the existing APIs or user interface it must include sufficient documentation to explain the use of the new or updated feature. Likewise the [CHANGELOG][changelog] should be updated with a summary of the change and link to the pull request.
+If the contribution changes the existing APIs or user interface it must include sufficient documentation to explain the use of the new or updated feature. Likewise the [CHANGELOG][/CHANGELOG.md] should be updated with a summary of the change and link to the pull request.
 
 
 [golang-style-doc]: https://github.com/golang/go/wiki/CodeReviewComments

--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ k8gb is very well tested with the following environment options
 
 ## Contributing
 
-See [CONTRIBUTING.md](/CONTRIBUTING.md)
+See [CONTRIBUTING](/docs/contrib.md)

--- a/docs/contrib.md
+++ b/docs/contrib.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md


### PR DESCRIPTION
* For some reason jekyll does not render anything that is
  named like CONTRIBUTING.md and shows it as a plain text
* Workaround it by renamed symlink
* Inline Changelog link fix