### PR TITLE
Integrate depresolver

### DIFF
--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -64,13 +64,12 @@ type Config struct {
 	EdgeDNSZone string
 	// DNSZone controlled by gslb; e.g. cloud.example.com
 	DNSZone string
-	// DNSTypeRoute53 switch
-	// TODO: hide for depresolver subscriber as depresolver retrieves EdgeDNSType. Maybe we can change configuration and set EdgeDNSType directly instead of DNSTypeRoute53 boolean
-	Route53Enabled bool
 	// Infoblox configuration
 	Infoblox Infoblox
 	// Override the behavior of GSLB in the test environments
 	Override Override
+	// route53Enabled hidden. EdgeDNSType defines all enabled Enabled types
+	route53Enabled bool
 }
 
 // DependencyResolver resolves configuration for GSLB

--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -33,7 +33,7 @@ func (dr *DependencyResolver) ResolveOperatorConfig() (*Config, error) {
 		dr.config.ReconcileRequeueSeconds, _ = env.GetEnvAsIntOrFallback(ReconcileRequeueSecondsKey, 30)
 		dr.config.ClusterGeoTag = env.GetEnvAsStringOrFallback(ClusterGeoTagKey, "")
 		dr.config.ExtClustersGeoTags = env.GetEnvAsArrayOfStringsOrFallback(ExtClustersGeoTagsKey, []string{})
-		dr.config.Route53Enabled = env.GetEnvAsBoolOrFallback(Route53EnabledKey, false)
+		dr.config.route53Enabled = env.GetEnvAsBoolOrFallback(Route53EnabledKey, false)
 		dr.config.EdgeDNSServer = env.GetEnvAsStringOrFallback(EdgeDNSServerKey, "")
 		dr.config.EdgeDNSZone = env.GetEnvAsStringOrFallback(EdgeDNSZoneKey, "")
 		dr.config.DNSZone = env.GetEnvAsStringOrFallback(DNSZoneKey, "")
@@ -110,7 +110,7 @@ func (dr *DependencyResolver) validateConfig(config *Config) (err error) {
 // getEdgeDNSType contains logic retrieving EdgeDNSType
 func getEdgeDNSType(config *Config) EdgeDNSType {
 	var t = DNSTypeNoEdgeDNS
-	if config.Route53Enabled {
+	if config.route53Enabled {
 		t = t | DNSTypeRoute53
 	}
 	if isNotEmpty(config.Infoblox.Host) {

--- a/controllers/depresolver/depresolver_test.go
+++ b/controllers/depresolver/depresolver_test.go
@@ -21,22 +21,21 @@ import (
 )
 
 var predefinedConfig = Config{
-	30,
-	"us",
-	[]string{"uk", "eu"},
-	DNSTypeInfoblox,
-	"cloud.example.com",
-	"8.8.8.8",
-	"example.com",
-	false,
-	Infoblox{
+	ReconcileRequeueSeconds: 30,
+	ClusterGeoTag:           "us",
+	ExtClustersGeoTags:      []string{"uk", "eu"},
+	EdgeDNSType:             DNSTypeInfoblox,
+	EdgeDNSServer:           "cloud.example.com",
+	EdgeDNSZone:             "8.8.8.8",
+	DNSZone:                 "example.com",
+	Infoblox: Infoblox{
 		"Infoblox.host.com",
 		"0.0.3",
 		443,
 		"Infoblox",
 		"secret",
 	},
-	Override{
+	Override: Override{
 		false,
 		false,
 	},
@@ -268,14 +267,14 @@ func TestResolveConfigWithMalformedRoute53Enabled(t *testing.T) {
 	config, err := resolver.ResolveOperatorConfig()
 	// assert
 	assert.NoError(t, err)
-	assert.Equal(t, false, config.Route53Enabled)
+	assert.Equal(t, false, config.route53Enabled)
 }
 
 func TestResolveConfigWithProperRoute53Enabled(t *testing.T) {
 	// arrange
 	defer cleanup()
 	expected := predefinedConfig
-	expected.Route53Enabled = true
+	expected.route53Enabled = true
 	expected.Infoblox.Host = ""
 	expected.EdgeDNSType = DNSTypeRoute53
 	// act,assert
@@ -286,7 +285,7 @@ func TestResolveConfigWithoutRoute53(t *testing.T) {
 	// arrange
 	defer cleanup()
 	expected := predefinedConfig
-	expected.Route53Enabled = false
+	expected.route53Enabled = false
 	// act,assert
 	arrangeVariablesAndAssert(t, expected, assert.NoError, Route53EnabledKey)
 }
@@ -302,7 +301,7 @@ func TestResolveConfigWithEmptyRoute53(t *testing.T) {
 	config, err := resolver.ResolveOperatorConfig()
 	// assert
 	assert.NoError(t, err)
-	assert.Equal(t, false, config.Route53Enabled)
+	assert.Equal(t, false, config.route53Enabled)
 }
 
 func TestResolveConfigWithEmptyEdgeDnsServer(t *testing.T) {
@@ -503,7 +502,7 @@ func TestRoute53IsEnabledAndInfobloxIsConfigured(t *testing.T) {
 	// arrange
 	defer cleanup()
 	expected := predefinedConfig
-	expected.Route53Enabled = true
+	expected.route53Enabled = true
 	expected.EdgeDNSType = DNSTypeRoute53 | DNSTypeInfoblox
 	expected.Infoblox.Host = "Infoblox.domain"
 	expected.Infoblox.Version = "0.0.1"
@@ -519,7 +518,7 @@ func TestRoute53IsDisabledAndInfobloxIsNotConfigured(t *testing.T) {
 	defer cleanup()
 	expected := predefinedConfig
 	expected.EdgeDNSType = DNSTypeNoEdgeDNS
-	expected.Route53Enabled = false
+	expected.route53Enabled = false
 	expected.Infoblox.Host = ""
 	// act,assert
 	// that's how our integration tests are running
@@ -530,7 +529,7 @@ func TestRoute53IsDisabledButInfobloxIsConfigured(t *testing.T) {
 	// arrange
 	defer cleanup()
 	expected := predefinedConfig
-	expected.Route53Enabled = false
+	expected.route53Enabled = false
 	expected.EdgeDNSType = DNSTypeInfoblox
 	expected.Infoblox.Host = "Infoblox.domain"
 	expected.Infoblox.Version = "0.0.1"
@@ -545,7 +544,7 @@ func TestRoute53IsEnabledButInfobloxIsNotConfigured(t *testing.T) {
 	// arrange
 	defer cleanup()
 	expected := predefinedConfig
-	expected.Route53Enabled = true
+	expected.route53Enabled = true
 	expected.EdgeDNSType = DNSTypeRoute53
 	expected.Infoblox.Host = ""
 	expected.Infoblox.Version = "0.0.1"
@@ -561,7 +560,7 @@ func TestInfobloxGridHostIsEmpty(t *testing.T) {
 	defer cleanup()
 	expected := predefinedConfig
 	expected.EdgeDNSType = DNSTypeRoute53
-	expected.Route53Enabled = true
+	expected.route53Enabled = true
 	expected.Infoblox.Host = ""
 	expected.Infoblox.Version = ""
 	expected.Infoblox.Port = 0
@@ -604,7 +603,7 @@ func TestInfobloxGridHostIsEmptyButInfobloxPropsAreFilled(t *testing.T) {
 	defer cleanup()
 	expected := predefinedConfig
 	expected.EdgeDNSType = DNSTypeRoute53
-	expected.Route53Enabled = true
+	expected.route53Enabled = true
 	expected.Infoblox.Host = ""
 	expected.Infoblox.Version = "0.0.1"
 	expected.Infoblox.Port = 443
@@ -619,7 +618,7 @@ func TestInfobloxGridHostIsUnset(t *testing.T) {
 	defer cleanup()
 	expected := predefinedConfig
 	expected.EdgeDNSType = DNSTypeNoEdgeDNS
-	expected.Route53Enabled = false
+	expected.route53Enabled = false
 	expected.Infoblox.Host = ""
 	expected.Infoblox.Version = "0.0.1"
 	expected.Infoblox.Port = 443
@@ -635,7 +634,7 @@ func TestInfobloxGridHostIsInvalid(t *testing.T) {
 	defer cleanup()
 	expected := predefinedConfig
 	expected.EdgeDNSType = DNSTypeInfoblox
-	expected.Route53Enabled = false
+	expected.route53Enabled = false
 	expected.Infoblox.Host = "dnfkjdnf kj"
 	expected.Infoblox.Version = "0.0.1"
 	expected.Infoblox.Port = 443
@@ -906,7 +905,7 @@ func configureEnvVar(config Config) {
 	_ = os.Setenv(EdgeDNSServerKey, config.EdgeDNSServer)
 	_ = os.Setenv(EdgeDNSZoneKey, config.EdgeDNSZone)
 	_ = os.Setenv(DNSZoneKey, config.DNSZone)
-	_ = os.Setenv(Route53EnabledKey, strconv.FormatBool(config.Route53Enabled))
+	_ = os.Setenv(Route53EnabledKey, strconv.FormatBool(config.route53Enabled))
 	_ = os.Setenv(InfobloxGridHostKey, config.Infoblox.Host)
 	_ = os.Setenv(InfobloxVersionKey, config.Infoblox.Version)
 	_ = os.Setenv(InfobloxPortKey, strconv.Itoa(config.Infoblox.Port))

--- a/controllers/fakedns.go
+++ b/controllers/fakedns.go
@@ -19,9 +19,9 @@ func oldEdgeTimestamp(threshold string) string {
 }
 
 var records = map[string][]string{
-	"localtargets-app3.cloud.example.com.": []string{"10.1.0.1", "10.1.0.2", "10.1.0.3"},
-	"test-gslb-heartbeat-eu.example.com.":  []string{oldEdgeTimestamp("10m")},
-	"test-gslb-heartbeat-za.example.com.":  []string{oldEdgeTimestamp("3m")},
+	"localtargets-app3.cloud.example.com.": {"10.1.0.1", "10.1.0.2", "10.1.0.3"},
+	"test-gslb-heartbeat-eu.example.com.":  {oldEdgeTimestamp("10m")},
+	"test-gslb-heartbeat-za.example.com.":  {oldEdgeTimestamp("3m")},
 }
 
 func parseQuery(m *dns.Msg) {
@@ -71,7 +71,7 @@ func handleDNSRequest(w dns.ResponseWriter, r *dns.Msg) {
 	}
 }
 
-func fakedns() {
+func fakeDNS() {
 	// attach request handler func
 	dns.HandleFunc("example.com.", handleDNSRequest)
 
@@ -84,12 +84,12 @@ func fakedns() {
 		defer func() {
 			err := server.Shutdown()
 			if err != nil {
-				log.Error(err, "Failed to shutdown fakedns server")
+				log.Error(err, "Failed to shutdown fakeDNS server")
 			}
 
 		}()
 		if err != nil {
-			log.Error(err, "Failed to start fakedns server")
+			log.Error(err, "Failed to start fakeDNS server")
 		}
 	}()
 }

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -120,10 +120,7 @@ func (r *GslbReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
-	result, err = r.ensureIngress(
-		req,
-		gslb,
-		ingress)
+	result, err = r.ensureIngress(gslb, ingress)
 	if result != nil {
 		return *result, err
 	}
@@ -135,10 +132,7 @@ func (r *GslbReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
-	result, err = r.ensureDNSEndpoint(
-		gslb.Namespace,
-		gslb,
-		dnsEndpoint)
+	result, err = r.ensureDNSEndpoint(gslb.Namespace, dnsEndpoint)
 	if result != nil {
 		return *result, err
 	}

--- a/controllers/ingress.go
+++ b/controllers/ingress.go
@@ -29,10 +29,7 @@ func (r *GslbReconciler) gslbIngress(gslb *k8gbv1beta1.Gslb) (*v1beta1.Ingress, 
 	return ingress, err
 }
 
-func (r *GslbReconciler) ensureIngress(request reconcile.Request,
-	instance *k8gbv1beta1.Gslb,
-	i *v1beta1.Ingress,
-) (*reconcile.Result, error) {
+func (r *GslbReconciler) ensureIngress(instance *k8gbv1beta1.Gslb, i *v1beta1.Ingress) (*reconcile.Result, error) {
 	found := &v1beta1.Ingress{}
 	err := r.Get(context.TODO(), types.NamespacedName{
 		Name:      instance.Name,


### PR DESCRIPTION
close(#170)

We now load all inputs during init time, instead of runtime.
Inputs are loaded once and validated. Any input is accessible from the 
[single source of truth](https://en.wikipedia.org/wiki/Single_source_of_truth): `.Config`
found in receiver `*GslbReconciler`.
Making Route53Enabled private.

transferred env vars:
 - DNS_ZONE
 - EXT_GSLB_CLUSTERS_GEO_TAGS
 - CLUSTER_GEO_TAG
 - EDGE_DNS_SERVER
 - INFOBLOX_GRID_HOST
 - INFOBLOX_WAPI_VERSION
 - INFOBLOX_WAPI_PORT
 - EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
 - EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
 - OVERRIDE_WITH_FAKE_EXT_DNS
 - OVERRIDE_WITH_FAKE_EXT_DNS
 - EDGE_DNS_ZONE
 - FAKE_INFOBLOX
