### PR TITLE
Use absolute URLs in case of file reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ k8gb is MIT licensed and accepts contributions via GitHub pull requests. This do
 ## Getting started
 
 - Fork the repository on GitHub
-- See the [local playground guide][docs/local.md] for testing environment setup
+- See the [local playground guide](/docs/local.md) for testing environment setup
 
 ## Reporting bugs and creating issues
 
@@ -31,7 +31,7 @@ Thanks for contributing!
 
 ### Testing
 
-* Unit tests should be updated for any functional code change at [test suite location](/controllers/gslb_controller_test.go).
+* Unit tests should be updated for any functional code change at [test suite location](https://github.com/AbsaOSS/k8gb/tree/master/controllers/gslb_controller_test.go).
 * Acceptance terratest suite is located [here](/terratest) and executable by `make terratest` target. These tests are changed only if the
  change is substantial enough to affect the main end-to-end flow.
 

--- a/README.md
+++ b/README.md
@@ -77,13 +77,15 @@ Internal k8gb architecture and its components are described [here](/docs/compone
 
 k8gb is very well tested with the following environment options
 
-| Type                             | Implementation                                                       |
-|----------------------------------|----------------------------------------------------------------------|
-| Kubernetes Version               | >= 1.14 (with [install workaround](/Makefile#L235)) >= 1.15 (Stable) |
-| Environment                      | On-prem(vSphere), AWS(EKS)                                           |
-| Ingress Controller               | NGINX                                                                |
-| EdgeDNS                          | Infoblox, Route53                                                    |
+| Type                             | Implementation                                                          |
+|----------------------------------|-------------------------------------------------------------------------|
+| Kubernetes Version               | >= 1.14 (with [install workaround][install-workaround] >= 1.15 (Stable) |
+| Environment                      | On-prem(vSphere), AWS(EKS)                                              |
+| Ingress Controller               | NGINX                                                                   |
+| EdgeDNS                          | Infoblox, Route53                                                       |
 
 ## Contributing
 
 See [CONTRIBUTING.md](/CONTRIBUTING.md)
+
+[install-workaround]: https://github.com/AbsaOSS/k8gb/tree/master/Makefile#L235

--- a/docs/deploy_route53.md
+++ b/docs/deploy_route53.md
@@ -6,14 +6,14 @@ Here we provide an example of k8gb deployment in AWS context with Route53 as edg
 
 Two EKS clusters in `eu-west-1` and `us-east-1`.
 
-Terraform code for cluster reference setup can be found [here](/docs/examples/route53/)
+Terraform code for cluster reference setup can be found [here](https://github.com/AbsaOSS/k8gb/tree/master/docs/examples/route53)
 
 Feel free to reuse this code fully or partially and adapt for your existing scenario
 things like IRSA(IAM Roles for Service Accounts)
 
 ## Deploy k8gb
 
-Example values.yaml override configs can be found [here](/docs/examples/route53/k8gb)
+Example values.yaml override configs can be found [here](https://github.com/AbsaOSS/k8gb/tree/master/docs/examples/route53/k8gb)
 
 You can use `helm` to deploy stable release from helm repo
 
@@ -42,7 +42,7 @@ cluster, we assume that you switch kubctl context and apply the same command to 
 make deploy-test-apps
 ```
 
-* Modify sample [Gslb CR](/docs/examples/route53/k8gb/gslb-failover.yaml) to reflect your
+* Modify sample [Gslb CR](https://github.com/AbsaOSS/k8gb/tree/master/docs/examples/route53/k8gb/gslb-failover.yaml) to reflect your
 `dnsZone`, `edgeDNSZone`, valid `hostedZoneID` and `irsaRole` ARN.
 
 * Apply Gslb CR to *each* cluster

--- a/docs/local.md
+++ b/docs/local.md
@@ -22,7 +22,7 @@
     - ensure you are able to push/pull from your docker registry
     - to run multiple clusters reserve 8GB of memory
 
-      ![](docs/images/docker_settings.png)
+      ![](/docs/images/docker_settings.png)
       <div>
         <sup>above screenshot is for <strong>Docker for Mac</strong> and that options for other Docker distributions may vary</sup>
       </div>
@@ -64,8 +64,8 @@ eed5a40bbfb6ee97, started, etcd-cluster-xsjmwdkdf8, http://etcd-cluster-xsjmwdkd
 ...
 ```
 
-Cluster [test-gslb1](/deploy/kind/cluster.yaml) is exposing external DNS on default port `:5053`
-while [test-gslb2](/deploy/kind/cluster2.yaml) on port `:5054`.
+Cluster [test-gslb1](https://github.com/AbsaOSS/k8gb/tree/master/deploy/kind/cluster.yaml) is exposing external DNS on default port `:5053`
+while [test-gslb2](https://github.com/AbsaOSS/k8gb/tree/master/deploy/kind/cluster2.yaml) on port `:5054`.
 ```shell script
 dig @localhost localtargets.app3.cloud.example.com -p 5053 && dig -p 5054 @localhost localtargets.app3.cloud.example.com
 ```
@@ -91,7 +91,7 @@ curl localhost:80 -H "Host:app3.cloud.example.com" && curl localhost:81 -H "Host
 
 #### Run integration tests
 
-There is wide range of scenarios which **GSLB** provides and all of them are covered within [tests](/terratest).
+There is wide range of scenarios which **GSLB** provides and all of them are covered within [tests](https://github.com/AbsaOSS/k8gb/tree/master/terratest).
 To check whether everything is running properly execute [terratest](https://terratest.gruntwork.io/) :
 
 ```shell script
@@ -112,7 +112,7 @@ make destroy-full-local-setup
 Both clusters have [podinfo](https://github.com/stefanprodan/podinfo) installed on the top, where each
 cluster has been tagged to serve a different region. In this demo we will hit podinfo by `wget -qO - app3.cloud.example.com` and depending
 on region will podinfo return **us** or **eu**. In current round robin implementation are IP addresses randomly picked.
-See [Gslb manifest with round robin strategy](/deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr.yaml)
+See [Gslb manifest with round robin strategy](https://github.com/AbsaOSS/k8gb/tree/master/deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr.yaml)
 
 Run several times command below and watch `message` field.
 ```shell script
@@ -142,7 +142,7 @@ As expected result you should see podinfo message changing
 Both clusters have [podinfo](https://github.com/stefanprodan/podinfo) installed on the top where each
 cluster has been tagged to serve a different region. In this demo we will hit podinfo by `wget -qO - failover.cloud.example.com` and depending
 on whether podinfo is running inside the cluster it returns only **eu** or **us**.
-See [Gslb manifest with failover strategy](/deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr_failover.yaml)
+See [Gslb manifest with failover strategy](https://github.com/AbsaOSS/k8gb/tree/master/deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr_failover.yaml)
 
 Switch GLSB to failover mode:
 ```shell script


### PR DESCRIPTION
Unfortunately relative paths are not working in Github Pages
leading to 404 in cases when we reference file/dir in the github
repository.

So unless the referenced file is md or a graphic file like png/svg
we have to stick with the absolute url to the master branch