### PR TITLE
Change context initialisation, fix helm upgrade

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 		Log:    ctrl.Log.WithName("controllers").WithName("Gslb"),
 		Scheme: mgr.GetScheme(),
 	}
-	reconciler.DepResolver = depresolver.NewDependencyResolver(context.TODO(), reconciler.Client)
+	reconciler.DepResolver = depresolver.NewDependencyResolver(context.Background(), reconciler.Client)
 	reconciler.Config, err = reconciler.DepResolver.ResolveOperatorConfig()
 	if err != nil {
 		setupLog.Error(err, "reading config env variables")


### PR DESCRIPTION
close #168 

I tested location for initiating depresolver against blank [kubebuilder project](https://book.kubebuilder.io/quick-start.html). No changes needed in depresolver init location. 

I changed context initialisation to [Background](https://godoc.org/context#Background) which is typically used by the main function, initialization, and tests, and as the top-level Context for incoming requests.

I also switched to [stable helm repo](https://helm.sh/blog/new-location-stable-incubator-charts/) to pass terratests (already implemented in #201 ).
