### PR TITLE
Contexts complient with kube-builder

### DIFF
--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -7,7 +7,6 @@
 package depresolver
 
 import (
-	"context"
 	"sync"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,7 +75,6 @@ type Config struct {
 type DependencyResolver struct {
 	client      client.Client
 	config      *Config
-	context     context.Context
 	onceConfig  sync.Once
 	onceSpec    sync.Once
 	errorConfig error
@@ -84,9 +82,8 @@ type DependencyResolver struct {
 }
 
 // NewDependencyResolver returns a new depresolver.DependencyResolver
-func NewDependencyResolver(context context.Context, client client.Client) *DependencyResolver {
+func NewDependencyResolver(client client.Client) *DependencyResolver {
 	resolver := new(DependencyResolver)
 	resolver.client = client
-	resolver.context = context
 	return resolver
 }

--- a/controllers/depresolver/depresolver_spec.go
+++ b/controllers/depresolver/depresolver_spec.go
@@ -1,6 +1,8 @@
 package depresolver
 
 import (
+	"context"
+
 	k8gbv1beta1 "github.com/AbsaOSS/k8gb/api/v1beta1"
 )
 
@@ -12,7 +14,7 @@ var predefinedStrategy = k8gbv1beta1.Strategy{
 // ResolveGslbSpec executes once during reconciliation. At first cycle it reads
 // omitempty properties and attach predefined values in case they are not defined.
 // ResolveGslbSpec returns error if any input is invalid
-func (dr *DependencyResolver) ResolveGslbSpec(gslb *k8gbv1beta1.Gslb) error {
+func (dr *DependencyResolver) ResolveGslbSpec(ctx context.Context, gslb *k8gbv1beta1.Gslb) error {
 	dr.onceSpec.Do(func() {
 		strategy := &gslb.Spec.Strategy
 		// set predefined values if missing in the yaml
@@ -24,7 +26,7 @@ func (dr *DependencyResolver) ResolveGslbSpec(gslb *k8gbv1beta1.Gslb) error {
 		}
 		dr.errorSpec = dr.validateSpec(strategy)
 		if dr.errorSpec == nil {
-			dr.errorSpec = dr.client.Update(dr.context, gslb)
+			dr.errorSpec = dr.client.Update(ctx, gslb)
 		}
 	})
 	return dr.errorSpec

--- a/controllers/depresolver/depresolver_test.go
+++ b/controllers/depresolver/depresolver_test.go
@@ -44,9 +44,9 @@ var predefinedConfig = Config{
 func TestResolveSpecWithFilledFields(t *testing.T) {
 	// arrange
 	cl, gslb := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
-	err := resolver.ResolveGslbSpec(gslb)
+	err := resolver.ResolveGslbSpec(context.TODO(), gslb)
 	// assert
 	assert.NoError(t, err)
 	assert.Equal(t, 35, gslb.Spec.Strategy.DNSTtlSeconds)
@@ -56,9 +56,9 @@ func TestResolveSpecWithFilledFields(t *testing.T) {
 func TestResolveSpecWithoutFields(t *testing.T) {
 	// arrange
 	cl, gslb := getTestContext("./testdata/free_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
-	err := resolver.ResolveGslbSpec(gslb)
+	err := resolver.ResolveGslbSpec(context.TODO(), gslb)
 	// assert
 	assert.NoError(t, err)
 	assert.Equal(t, predefinedStrategy.DNSTtlSeconds, gslb.Spec.Strategy.DNSTtlSeconds)
@@ -68,9 +68,9 @@ func TestResolveSpecWithoutFields(t *testing.T) {
 func TestResolveSpecWithZeroSplitBrain(t *testing.T) {
 	// arrange
 	cl, gslb := getTestContext("./testdata/filled_omitempty_with_zero_splitbrain.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
-	err := resolver.ResolveGslbSpec(gslb)
+	err := resolver.ResolveGslbSpec(context.TODO(), gslb)
 	// assert
 	assert.NoError(t, err)
 	assert.Equal(t, 35, gslb.Spec.Strategy.DNSTtlSeconds)
@@ -80,9 +80,9 @@ func TestResolveSpecWithZeroSplitBrain(t *testing.T) {
 func TestResolveSpecWithEmptyFields(t *testing.T) {
 	// arrange
 	cl, gslb := getTestContext("./testdata/invalid_omitempty_empty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
-	err := resolver.ResolveGslbSpec(gslb)
+	err := resolver.ResolveGslbSpec(context.TODO(), gslb)
 	// assert
 	assert.NoError(t, err)
 	assert.Equal(t, predefinedStrategy.DNSTtlSeconds, gslb.Spec.Strategy.DNSTtlSeconds)
@@ -92,9 +92,9 @@ func TestResolveSpecWithEmptyFields(t *testing.T) {
 func TestResolveSpecWithNegativeFields(t *testing.T) {
 	// arrange
 	cl, gslb := getTestContext("./testdata/invalid_omitempty_negative.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
-	err := resolver.ResolveGslbSpec(gslb)
+	err := resolver.ResolveGslbSpec(context.TODO(), gslb)
 	// assert
 	assert.Error(t, err)
 }
@@ -102,11 +102,12 @@ func TestResolveSpecWithNegativeFields(t *testing.T) {
 func TestSpecRunOnce(t *testing.T) {
 	// arrange
 	cl, gslb := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	ctx := context.Background()
+	resolver := NewDependencyResolver(cl)
 	// act
-	err1 := resolver.ResolveGslbSpec(gslb)
+	err1 := resolver.ResolveGslbSpec(ctx, gslb)
 	gslb.Spec.Strategy.DNSTtlSeconds = -100
-	err2 := resolver.ResolveGslbSpec(gslb)
+	err2 := resolver.ResolveGslbSpec(ctx, gslb)
 	// assert
 	assert.NoError(t, err1)
 	// err2 would not be empty
@@ -131,7 +132,7 @@ func TestResolveConfigWithoutEnvVarsSet(t *testing.T) {
 	defaultConfig.EdgeDNSType = DNSTypeNoEdgeDNS
 	defaultConfig.ExtClustersGeoTags = []string{}
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
 	config, err := resolver.ResolveOperatorConfig()
 	// assert
@@ -154,7 +155,7 @@ func TestResolveConfigWithTextReconcileRequeueSecondsSync(t *testing.T) {
 	configureEnvVar(predefinedConfig)
 	_ = os.Setenv(ReconcileRequeueSecondsKey, "invalid")
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
 	config, err := resolver.ResolveOperatorConfig()
 	// assert
@@ -168,7 +169,7 @@ func TestResolveConfigWithEmptyReconcileRequeueSecondsSync(t *testing.T) {
 	configureEnvVar(predefinedConfig)
 	_ = os.Setenv(ReconcileRequeueSecondsKey, "")
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
 	config, err := resolver.ResolveOperatorConfig()
 	// assert
@@ -200,7 +201,7 @@ func TestResolveConfigWithEmptyReconcileRequeueSecondsKey(t *testing.T) {
 	configureEnvVar(predefinedConfig)
 	_ = os.Setenv(ReconcileRequeueSecondsKey, "")
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
 	config, err := resolver.ResolveOperatorConfig()
 	// assert
@@ -242,7 +243,7 @@ func TestConfigRunOnce(t *testing.T) {
 	defer cleanup()
 	configureEnvVar(predefinedConfig)
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
 	config1, err1 := resolver.ResolveOperatorConfig()
 	_ = os.Setenv(ReconcileRequeueSecondsKey, "100")
@@ -262,7 +263,7 @@ func TestResolveConfigWithMalformedRoute53Enabled(t *testing.T) {
 	configureEnvVar(predefinedConfig)
 	_ = os.Setenv(Route53EnabledKey, "i.am.wrong??.")
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
 	config, err := resolver.ResolveOperatorConfig()
 	// assert
@@ -296,7 +297,7 @@ func TestResolveConfigWithEmptyRoute53(t *testing.T) {
 	configureEnvVar(predefinedConfig)
 	_ = os.Setenv(Route53EnabledKey, "")
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
 	config, err := resolver.ResolveOperatorConfig()
 	// assert
@@ -815,7 +816,7 @@ func TestResolveConfigEnableFakeDNSAsInvalidValue(t *testing.T) {
 	configureEnvVar(predefinedConfig)
 	_ = os.Setenv(OverrideWithFakeDNSKey, "i.am.wrong??.")
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
 	config, err := resolver.ResolveOperatorConfig()
 	// assert
@@ -855,7 +856,7 @@ func TestResolveConfigEnableFakeInfobloxAsInvalidValue(t *testing.T) {
 	configureEnvVar(predefinedConfig)
 	_ = os.Setenv(OverrideFakeInfobloxKey, "i.am.wrong??.")
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
 	config, err := resolver.ResolveOperatorConfig()
 	// assert
@@ -879,7 +880,7 @@ func arrangeVariablesAndAssert(t *testing.T, expected Config,
 		_ = os.Unsetenv(v)
 	}
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
-	resolver := NewDependencyResolver(context.TODO(), cl)
+	resolver := NewDependencyResolver(cl)
 	// act
 	config, err := resolver.ResolveOperatorConfig()
 	// assert

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -57,12 +57,12 @@ const gslbFinalizer = "finalizer.k8gb.absa.oss"
 
 // Reconcile runs main reconiliation loop
 func (r *GslbReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	_ = context.Background()
+	ctx := context.Background()
 	log := r.Log.WithValues("gslb", req.NamespacedName)
 
 	// Fetch the Gslb instance
 	gslb := &k8gbv1beta1.Gslb{}
-	err := r.Get(context.TODO(), req.NamespacedName, gslb)
+	err := r.Get(ctx, req.NamespacedName, gslb)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -76,7 +76,7 @@ func (r *GslbReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	var result *ctrl.Result
 
-	err = r.DepResolver.ResolveGslbSpec(gslb)
+	err = r.DepResolver.ResolveGslbSpec(ctx, gslb)
 	if err != nil {
 		log.Error(err, "resolving spec.strategy")
 		return ctrl.Result{}, err
@@ -98,7 +98,7 @@ func (r *GslbReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			// Remove gslbFinalizer. Once all finalizers have been
 			// removed, the object will be deleted.
 			gslb.SetFinalizers(remove(gslb.GetFinalizers(), gslbFinalizer))
-			err := r.Update(context.TODO(), gslb)
+			err := r.Update(ctx, gslb)
 			if err != nil {
 				return ctrl.Result{}, err
 			}

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -983,7 +983,7 @@ func provideSettings(t *testing.T, expected depresolver.Config) (settings testSe
 	// Create a fake client to mock API calls.
 	cl := fake.NewFakeClientWithScheme(s, objs...)
 	// Create config
-	config, err := depresolver.NewDependencyResolver(context.TODO(), cl).ResolveOperatorConfig()
+	config, err := depresolver.NewDependencyResolver(cl).ResolveOperatorConfig()
 	if err != nil {
 		t.Fatalf("config error: (%v)", err)
 	}
@@ -993,7 +993,7 @@ func provideSettings(t *testing.T, expected depresolver.Config) (settings testSe
 		Log:    ctrl.Log.WithName("setup"),
 		Scheme: s,
 	}
-	r.DepResolver = depresolver.NewDependencyResolver(context.TODO(), r.Client)
+	r.DepResolver = depresolver.NewDependencyResolver(r.Client)
 	r.Config = config
 	// Mock request to simulate Reconcile() being called on an event for a
 	// watched resource .

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"os"
 
@@ -89,7 +88,7 @@ func main() {
 		Log:    ctrl.Log.WithName("controllers").WithName("Gslb"),
 		Scheme: mgr.GetScheme(),
 	}
-	reconciler.DepResolver = depresolver.NewDependencyResolver(context.Background(), reconciler.Client)
+	reconciler.DepResolver = depresolver.NewDependencyResolver(reconciler.Client)
 	reconciler.Config, err = reconciler.DepResolver.ResolveOperatorConfig()
 	if err != nil {
 		setupLog.Error(err, "reading config env variables")


### PR DESCRIPTION
In order to migration operator-sdk 1.0 we should use contexts to be kube-builder compliant. To achieve this, I [reuse default Background context](https://github.com/AbsaOSS/k8gb/blob/master/controllers/gslb_controller.go#L60) from reconciliation loop.  see: https://book.kubebuilder.io/cronjob-tutorial/controller-implementation.html#implementing-a-controller; 
```go
func (r *CronJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
    ctx := context.Background()
    log := r.Log.WithValues("cronjob", req.NamespacedName)

```


I changed
 - depresolver doesn't hold context internally
 - update tests
 - use default context instead of context.TODO() within reconciliation queue
