### PR TITLE
Enable Gslb with Ingress Annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,11 @@ deploy-full-terratest-setup:
 	kubectl config use-context kind-$(CLUSTER_GSLB1)
 	kubectl get pods -A
 
+.PHONY: deploy-gslb-operator
+deploy-gslb-operator:
+	cd chart/k8gb && helm dependency update
+	helm -n k8gb upgrade -i k8gb chart/k8gb -f $(VALUES_YAML) $(HELM_ARGS)
+
 # workaround until https://github.com/crossplaneio/crossplane/issues/1170 solved
 .PHONY: deploy-gslb-operator-14
 deploy-gslb-operator-14:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Internal k8gb architecture and its components are described [here](/docs/compone
 * [AWS based deployment with Route53 integration](/docs/deploy_route53.md)
 * [Local playground for testing and development](/docs/local.md)
 * [Metrics](/docs/metrics.md)
+* [Ingress annotations](/docs/ingress_annotations.md)
 
 ## Production Readiness
 

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.7.0
+appVersion: 0.7.1
 
 dependencies:
   - name: coredns

--- a/controllers/dnsupdate.go
+++ b/controllers/dnsupdate.go
@@ -142,9 +142,9 @@ func (r *GslbReconciler) gslbDNSEndpoint(gslb *k8gbv1beta1.Gslb) (*externaldns.D
 		}
 		if len(externalTargets) > 0 {
 			switch gslb.Spec.Strategy.Type {
-			case "roundRobin":
+			case roundRobinStrategy:
 				finalTargets = append(finalTargets, externalTargets...)
-			case "failover":
+			case failoverStrategy:
 				// If cluster is Primary
 				if gslb.Spec.Strategy.PrimaryGeoTag == r.Config.ClusterGeoTag {
 					// If cluster is Primary and Healthy return only own targets

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -210,7 +210,7 @@ func (r *GslbReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			Name:      a.Meta.GetName(),
 		}, ingressToReuse)
 		if err != nil {
-			log.Info(fmt.Sprintf("Ingress(%s) does not exist anymore. Skipping...", a.Meta.GetName()))
+			log.Info(fmt.Sprintf("Ingress(%s) does not exist anymore. Skipping Glsb creation...", a.Meta.GetName()))
 			return
 		}
 		gslbExist := &k8gbv1beta1.Gslb{}

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -240,6 +240,10 @@ func (r *GslbReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					gslb.Spec.Strategy.PrimaryGeoTag = annotationValue
 				}
 			}
+			if gslb.Spec.Strategy.PrimaryGeoTag == "" {
+				log.Info("k8gb.io/primarygeotag annotation is missing, skipping Gslb creation...")
+				return
+			}
 		}
 
 		log.Info(fmt.Sprintf("Creating new Gslb(%s) out of Ingress annotation", gslb.Name))

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/AbsaOSS/k8gb/controllers/depresolver"
@@ -25,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	types "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -162,7 +164,8 @@ func (r *GslbReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 // SetupWithManager configures controller manager
 func (r *GslbReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Figure out Gslb resource name to Reconcile when non controlled Endpoint is updated
-	mapFn := handler.ToRequestsFunc(
+
+	endpointMapFn := handler.ToRequestsFunc(
 		func(a handler.MapObject) []reconcile.Request {
 			gslbList := &k8gbv1beta1.GslbList{}
 			opts := []client.ListOption{
@@ -195,13 +198,78 @@ func (r *GslbReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return nil
 		})
 
+	createGslbFromIngress := func(annotationKey string, annotationValue string, a handler.MapObject, strategy string) {
+		log.Info(fmt.Sprintf("Detected strategy annotation(%s:%s) on Ingress(%s)",
+			annotationKey, annotationValue, a.Meta.GetName()))
+		c := mgr.GetClient()
+		ingressToReuse := &v1beta1.Ingress{}
+		err := c.Get(context.Background(), client.ObjectKey{
+			Namespace: a.Meta.GetNamespace(),
+			Name:      a.Meta.GetName(),
+		}, ingressToReuse)
+		if err != nil {
+			log.Info(fmt.Sprintf("Ingress(%s) does not exist anymore. Skipping...", a.Meta.GetName()))
+			return
+		}
+		gslbExist := &k8gbv1beta1.Gslb{}
+		err = c.Get(context.Background(), client.ObjectKey{
+			Namespace: a.Meta.GetNamespace(),
+			Name:      a.Meta.GetName(),
+		}, gslbExist)
+		if err == nil {
+			log.Info(fmt.Sprintf("Gslb(%s) already exists. Skipping...", gslbExist.Name))
+			return
+		}
+		gslb := &k8gbv1beta1.Gslb{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   a.Meta.GetNamespace(),
+				Name:        a.Meta.GetName(),
+				Annotations: a.Meta.GetAnnotations(),
+			},
+			Spec: k8gbv1beta1.GslbSpec{
+				Ingress: ingressToReuse.Spec,
+				Strategy: k8gbv1beta1.Strategy{
+					Type: strategy,
+				},
+			},
+		}
+
+		if strategy == "failover" {
+			for annotationKey, annotationValue := range a.Meta.GetAnnotations() {
+				if annotationKey == "k8gb.io/primarygeotag" {
+					gslb.Spec.Strategy.PrimaryGeoTag = annotationValue
+				}
+			}
+		}
+
+		log.Info(fmt.Sprintf("Creating new Gslb(%s) out of Ingress annotation", gslb.Name))
+		_ = c.Create(context.Background(), gslb)
+	}
+	ingressMapFn := handler.ToRequestsFunc(
+		func(a handler.MapObject) []reconcile.Request {
+			for annotationKey, annotationValue := range a.Meta.GetAnnotations() {
+				if annotationKey == "k8gb.io/strategy" {
+					switch annotationValue {
+					case "roundRobin":
+						createGslbFromIngress(annotationKey, annotationKey, a, "roundRobin")
+					case "failover":
+						createGslbFromIngress(annotationKey, annotationKey, a, "failover")
+					}
+				}
+			}
+			return nil
+		})
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8gbv1beta1.Gslb{}).
 		Owns(&v1beta1.Ingress{}).
 		Owns(&externaldns.DNSEndpoint{}).
 		Watches(&source.Kind{Type: &corev1.Endpoints{}},
 			&handler.EnqueueRequestsFromMapFunc{
-				ToRequests: mapFn}).
+				ToRequests: endpointMapFn}).
+		Watches(&source.Kind{Type: &v1beta1.Ingress{}},
+			&handler.EnqueueRequestsFromMapFunc{
+				ToRequests: ingressMapFn}).
 		Complete(r)
 
 }

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -53,6 +53,8 @@ type GslbReconciler struct {
 
 const k8gbNamespace = "k8gb"
 const gslbFinalizer = "finalizer.k8gb.absa.oss"
+const roundRobinStrategy = "roundRobin"
+const failoverStrategy = "failover"
 
 // +kubebuilder:rbac:groups=k8gb.absa.oss,resources=gslbs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=k8gb.absa.oss,resources=gslbs/status,verbs=get;update;patch
@@ -234,7 +236,7 @@ func (r *GslbReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			},
 		}
 
-		if strategy == "failover" {
+		if strategy == failoverStrategy {
 			for annotationKey, annotationValue := range a.Meta.GetAnnotations() {
 				if annotationKey == "k8gb.io/primarygeotag" {
 					gslb.Spec.Strategy.PrimaryGeoTag = annotationValue
@@ -254,10 +256,10 @@ func (r *GslbReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			for annotationKey, annotationValue := range a.Meta.GetAnnotations() {
 				if annotationKey == "k8gb.io/strategy" {
 					switch annotationValue {
-					case "roundRobin":
-						createGslbFromIngress(annotationKey, annotationKey, a, "roundRobin")
-					case "failover":
-						createGslbFromIngress(annotationKey, annotationKey, a, "failover")
+					case roundRobinStrategy:
+						createGslbFromIngress(annotationKey, annotationKey, a, roundRobinStrategy)
+					case failoverStrategy:
+						createGslbFromIngress(annotationKey, annotationKey, a, failoverStrategy)
 					}
 				}
 			}

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -219,7 +219,7 @@ func (r *GslbReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			Name:      a.Meta.GetName(),
 		}, gslbExist)
 		if err == nil {
-			log.Info(fmt.Sprintf("Gslb(%s) already exists. Skipping...", gslbExist.Name))
+			log.Info(fmt.Sprintf("Gslb(%s) already exists. Skipping Gslb creation...", gslbExist.Name))
 			return
 		}
 		gslb := &k8gbv1beta1.Gslb{

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -807,6 +807,23 @@ func TestRoute53ZoneDelegationGarbageCollection(t *testing.T) {
 	require.Error(t, err, "k8gb-ns-route53 DNSEndpoint should be garbage collected")
 }
 
+func TestGslbSetsAnnotationsOnTheIngress(t *testing.T) {
+	// arrange
+	defer cleanup()
+
+	settings := provideSettings(t, predefinedConfig)
+
+	// act
+	reconcileAndUpdateGslb(t, settings)
+
+	// assert
+	ingress := &v1beta1.Ingress{}
+	err := settings.client.Get(context.Background(), client.ObjectKey{Namespace: settings.gslb.Namespace, Name: settings.gslb.Name}, ingress)
+	require.NoError(t, err, "Gslb should be created from annotated Ingress")
+
+	assert.Equal(t, map[string]string{"k8gb.io/strategy": "roundRobin"}, ingress.Annotations)
+}
+
 func TestMain(m *testing.M) {
 	// setup tests
 	fakeDNS()

--- a/controllers/ingress.go
+++ b/controllers/ingress.go
@@ -13,6 +13,13 @@ import (
 )
 
 func (r *GslbReconciler) gslbIngress(gslb *k8gbv1beta1.Gslb) (*v1beta1.Ingress, error) {
+	if gslb.Annotations == nil {
+		gslb.Annotations = make(map[string]string)
+	}
+	gslb.Annotations["k8gb.io/strategy"] = gslb.Spec.Strategy.Type
+	if gslb.Spec.Strategy.PrimaryGeoTag != "" {
+		gslb.Annotations["k8gb.io/primarygeotag"] = gslb.Spec.Strategy.PrimaryGeoTag
+	}
 	ingress := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        gslb.Name,

--- a/docs/ingress_annotations.md
+++ b/docs/ingress_annotations.md
@@ -1,0 +1,9 @@
+# Ingress Annotations
+
+Instead of direct Gslb resource creation there is ability to enable global load balancing
+by setting annotations on the standard Ingress objects.
+
+| Annotation            | Possible Values        |
+|-----------------------|------------------------|
+| k8gb.io/strategy      | roundRobin \| failover |
+| k8gb.io/primarygeotag | arbitrary tag, e.g. eu |

--- a/terratest/examples/ingress-annotation-failover.yaml
+++ b/terratest/examples/ingress-annotation-failover.yaml
@@ -1,0 +1,30 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    k8gb.io/strategy: failover
+    k8gb.io/primarygeotag: eu
+  name: test-gslb-annotation-failover
+spec:
+  rules:
+  - host: app1.cloud.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: non-existing-app
+          servicePort: http
+        path: /
+  - host: app2.cloud.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: unhealthy-app
+          servicePort: http
+        path: /
+  - host: app3.cloud.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: frontend-podinfo
+          servicePort: http
+        path: /

--- a/terratest/examples/ingress-annotation-rr.yaml
+++ b/terratest/examples/ingress-annotation-rr.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    k8gb.io/strategy: roundRobin
+  name: test-gslb-annotation
+spec:
+  rules:
+  - host: app1.cloud.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: non-existing-app
+          servicePort: http
+        path: /
+  - host: app2.cloud.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: unhealthy-app
+          servicePort: http
+        path: /
+  - host: app3.cloud.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: frontend-podinfo
+          servicePort: http
+        path: /

--- a/terratest/test/helpers.go
+++ b/terratest/test/helpers.go
@@ -13,12 +13,13 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//GetIngressIPs returns slice of IP's related to ingress
+// GetIngressIPs returns slice of IP's related to ingress
 func GetIngressIPs(t *testing.T, options *k8s.KubectlOptions, ingressName string) []string {
 	var ingressIPs []string
 	ingress := k8s.GetIngress(t, options, ingressName)
@@ -28,7 +29,7 @@ func GetIngressIPs(t *testing.T, options *k8s.KubectlOptions, ingressName string
 	return ingressIPs
 }
 
-//Dig gets sorted slice of records related to dnsName
+// Dig gets sorted slice of records related to dnsName
 func Dig(t *testing.T, dnsServer string, dnsPort int, dnsName string) ([]string, error) {
 	port := fmt.Sprintf("-p%v", dnsPort)
 	dnsServer = fmt.Sprintf("@%s", dnsServer)
@@ -136,4 +137,11 @@ func assertGslbStatus(t *testing.T, options *k8s.KubectlOptions, gslbName string
 		actualHealthStatus,
 		expectedHealthStatus)
 	require.NoError(t, err)
+}
+
+func assertGslbSpec(t *testing.T, options *k8s.KubectlOptions, gslbName string, specPath string, expectedValue string) {
+	t.Helper()
+	actualValue, err := k8s.RunKubectlAndGetOutputE(t, options, "get", "gslb", gslbName, "-o", fmt.Sprintf("custom-columns=SERVICESTATUS:%s", specPath), "--no-headers")
+	require.NoError(t, err)
+	assert.Equal(t, expectedValue, actualValue)
 }

--- a/terratest/test/k8gb_ingress_annotation_failover_test.go
+++ b/terratest/test/k8gb_ingress_annotation_failover_test.go
@@ -1,0 +1,47 @@
+package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+// Basic k8gb deployment test that is verifying that associated ingress is getting created
+func TestK8gbIngressAnnotationFailover(t *testing.T) {
+	t.Parallel()
+
+	// Path to the Kubernetes resource config we will test
+	kubeResourcePath, err := filepath.Abs("../examples/ingress-annotation-failover.yaml")
+	require.NoError(t, err)
+
+	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
+	// namespace for the resources for this test.
+	// Note that namespaces must be lowercase.
+	namespaceName := fmt.Sprintf("k8gb-basic-example-%s", strings.ToLower(random.UniqueId()))
+
+	// Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	// - Random namespace
+	options := k8s.NewKubectlOptions("", "", namespaceName)
+
+	k8s.CreateNamespace(t, options, namespaceName)
+
+	defer k8s.DeleteNamespace(t, options, namespaceName)
+
+	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+
+	k8s.KubectlApply(t, options, kubeResourcePath)
+
+	ingress := k8s.GetIngress(t, options, "test-gslb-annotation-failover")
+	require.Equal(t, ingress.Name, "test-gslb-annotation-failover")
+	assertGslbStatus(t, options, "test-gslb-annotation-failover", "app1.cloud.example.com:NotFound app2.cloud.example.com:NotFound app3.cloud.example.com:NotFound")
+	assertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.type", "failover")
+	assertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.primaryGeoTag", "eu")
+}

--- a/terratest/test/k8gb_ingress_annotation_rr_test.go
+++ b/terratest/test/k8gb_ingress_annotation_rr_test.go
@@ -1,0 +1,46 @@
+package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+// Basic k8gb deployment test that is verifying that associated ingress is getting created
+func TestK8gbIngressAnnotationRR(t *testing.T) {
+	t.Parallel()
+
+	// Path to the Kubernetes resource config we will test
+	kubeResourcePath, err := filepath.Abs("../examples/ingress-annotation-rr.yaml")
+	require.NoError(t, err)
+
+	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
+	// namespace for the resources for this test.
+	// Note that namespaces must be lowercase.
+	namespaceName := fmt.Sprintf("k8gb-basic-example-%s", strings.ToLower(random.UniqueId()))
+
+	// Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	// - Random namespace
+	options := k8s.NewKubectlOptions("", "", namespaceName)
+
+	k8s.CreateNamespace(t, options, namespaceName)
+
+	defer k8s.DeleteNamespace(t, options, namespaceName)
+
+	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+
+	k8s.KubectlApply(t, options, kubeResourcePath)
+
+	ingress := k8s.GetIngress(t, options, "test-gslb-annotation")
+	require.Equal(t, ingress.Name, "test-gslb-annotation")
+	assertGslbStatus(t, options, "test-gslb-annotation", "app1.cloud.example.com:NotFound app2.cloud.example.com:NotFound app3.cloud.example.com:NotFound")
+	assertGslbSpec(t, options, "test-gslb-annotation", ".spec.strategy.type", "roundRobin")
+}


### PR DESCRIPTION
* Resolves #200
* Reacts to Ingresses with specific annotations
* Dynamically creates Gslb resources according to annotation contents
* Associated unit and terratests
* Brief documentation