### PR TITLE
Primary geotag annotation fix

### DIFF
--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -821,7 +821,7 @@ func TestGslbSetsAnnotationsOnTheIngress(t *testing.T) {
 	err := settings.client.Get(context.Background(), client.ObjectKey{Namespace: settings.gslb.Namespace, Name: settings.gslb.Name}, ingress)
 	require.NoError(t, err, "Gslb should be created from annotated Ingress")
 
-	assert.Equal(t, map[string]string{"k8gb.io/strategy": "roundRobin"}, ingress.Annotations)
+	assert.Equal(t, map[string]string{strategyAnnotation: "roundRobin"}, ingress.Annotations)
 }
 
 func TestMain(m *testing.M) {

--- a/controllers/ingress.go
+++ b/controllers/ingress.go
@@ -16,9 +16,9 @@ func (r *GslbReconciler) gslbIngress(gslb *k8gbv1beta1.Gslb) (*v1beta1.Ingress, 
 	if gslb.Annotations == nil {
 		gslb.Annotations = make(map[string]string)
 	}
-	gslb.Annotations["k8gb.io/strategy"] = gslb.Spec.Strategy.Type
+	gslb.Annotations[strategyAnnotation] = gslb.Spec.Strategy.Type
 	if gslb.Spec.Strategy.PrimaryGeoTag != "" {
-		gslb.Annotations["k8gb.io/primarygeotag"] = gslb.Spec.Strategy.PrimaryGeoTag
+		gslb.Annotations[primaryGeoTagAnnotation] = gslb.Spec.Strategy.PrimaryGeoTag
 	}
 	ingress := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -7,9 +7,7 @@ import (
 )
 
 const (
-	gslbSubsystem = "gslb"
-)
-const (
+	gslbSubsystem   = "gslb"
 	healthyStatus   = "Healthy"
 	unhealthyStatus = "Unhealthy"
 	notFoundStatus  = "NotFound"

--- a/docs/ingress_annotations.md
+++ b/docs/ingress_annotations.md
@@ -3,7 +3,7 @@
 Instead of direct Gslb resource creation there is ability to enable global load balancing
 by setting annotations on the standard Ingress objects.
 
-| Annotation            | Possible Values        |
-|-----------------------|------------------------|
-| k8gb.io/strategy      | roundRobin \| failover |
-| k8gb.io/primarygeotag | arbitrary tag, e.g. eu |
+| Annotation             | Description      | Type                           |
+| ---------------------- | ---------------- | ------------------------------ |
+| k8gb.io/strategy       | Glsb strategy    | "`roundRobin`" \| "`failover`" |
+| k8gb.io/primary-geotag | Arbitrary geotag | string (e.g. "`eu`")           |

--- a/terratest/examples/ingress-annotation-failover.yaml
+++ b/terratest/examples/ingress-annotation-failover.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   annotations:
     k8gb.io/strategy: failover
-    k8gb.io/primarygeotag: eu
+    k8gb.io/primary-geotag: eu
   name: test-gslb-annotation-failover
 spec:
   rules:


### PR DESCRIPTION
This PR renames `k8gb.io/primarygeotag` annotation to `k8gb.io/primary-geotag` 
Closes #210 