### PR TITLE
Relax requirement on k8gb namespace name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,8 @@ tags
 ### JetBrains IDE ###
 .idea
 # End of idea tools
- 
 # Exclude chart tar.gz files
 chart/k8gb/charts/*.tgz
+
+# Ignore testing kubeconfigs
+kubeconfig*

--- a/chart/k8gb/templates/coredns-svc-aws.yaml
+++ b/chart/k8gb/templates/coredns-svc-aws.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
   name: k8gb-coredns-lb
-  namespace: k8gb
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: udp-53

--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -34,13 +34,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
-  namespace: k8gb
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: external-dns
-  namespace: k8gb
+  namespace: {{ .Release.Namespace }}
 {{ if .Values.route53.enabled }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.route53.irsaRole }}
@@ -51,7 +51,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: external-dns
-  namespace: k8gb
+  namespace: {{ .Release.Namespace }}
 spec:
   strategy:
     type: Recreate

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: k8gb
-  namespace: k8gb
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "chart.labels" . | indent 4  }}
 spec:
@@ -35,6 +35,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "k8gb"
             - name: K8GB_VERSION

--- a/chart/k8gb/templates/role_binding.yaml
+++ b/chart/k8gb/templates/role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: k8gb
-  namespace: k8gb
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: k8gb

--- a/chart/k8gb/templates/service_account.yaml
+++ b/chart/k8gb/templates/service_account.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: k8gb
-  namespace: k8gb
+  namespace: {{ .Release.Namespace }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/AbsaOSS/k8gb/controllers/depresolver"
@@ -40,6 +41,7 @@ import (
 	k8gbv1beta1 "github.com/AbsaOSS/k8gb/api/v1beta1"
 )
 
+var k8gbNamespace = os.Getenv("POD_NAMESPACE")
 var log = logf.Log.WithName("controller_gslb")
 
 // GslbReconciler reconciles a Gslb object
@@ -52,7 +54,6 @@ type GslbReconciler struct {
 }
 
 const (
-	k8gbNamespace           = "k8gb"
 	gslbFinalizer           = "finalizer.k8gb.absa.oss"
 	roundRobinStrategy      = "roundRobin"
 	failoverStrategy        = "failover"


### PR DESCRIPTION
* Do not rely on hardcoded `k8gb` namespace anymore
* Helm chart template fix
* Dynamically get current k8gb controller namespace
  with the help of Downward API
  https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables
* Resolves #129