### PR TITLE
NS1 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,12 @@ infoblox-secret:
 		--from-literal=EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME=$${WAPI_USERNAME} \
 		--from-literal=EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD=$${WAPI_PASSWORD}
 
+# creates ns1 secret in current cluster
+.PHONY: ns1-secret
+ns1-secret:
+	kubectl -n k8gb create secret generic ns1 \
+		--from-literal=apikey=$${NS1_APIKEY}
+
 # install CRDs into a cluster
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ infoblox-secret:
 .PHONY: ns1-secret
 ns1-secret:
 	kubectl -n k8gb create secret generic ns1 \
-		--from-literal=apikey=$${NS1_APIKEY}
+		--from-literal=apiKey=$${NS1_APIKEY}
 
 # install CRDs into a cluster
 .PHONY: install

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Internal k8gb architecture and its components are described [here](/docs/compone
 
 * [General deployment with Infoblox integration](/docs/deploy_infoblox.md)
 * [AWS based deployment with Route53 integration](/docs/deploy_route53.md)
+* [AWS based deployment with NS1 integration](/docs/deploy_ns1.md)
 * [Local playground for testing and development](/docs/local.md)
 * [Metrics](/docs/metrics.md)
 * [Ingress annotations](/docs/ingress_annotations.md)

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.1
+version: 0.7.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.7.1
+appVersion: 0.7.2
 
 dependencies:
   - name: coredns

--- a/chart/k8gb/templates/coredns-svc-aws.yaml
+++ b/chart/k8gb/templates/coredns-svc-aws.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.route53.enabled }}
+{{ if or .Values.route53.enabled .Values.ns1.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/chart/k8gb/templates/external-dns/external-dns-ns1.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns-ns1.yaml
@@ -31,7 +31,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: ns1
-              key: apikey
+              key: apiKey
       securityContext:
         fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
 {{ end }}

--- a/chart/k8gb/templates/external-dns/external-dns-ns1.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns-ns1.yaml
@@ -1,0 +1,37 @@
+{{ if .Values.ns1.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns-ns1
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns-ns1
+  template:
+    metadata:
+      labels:
+        app: external-dns-ns1
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: {{ .Values.externaldns.image }}
+        args:
+        - --source=crd
+        - --domain-filter={{ .Values.k8gb.edgeDNSZone }} # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
+        - --annotation-filter=k8gb.absa.oss/dnstype=ns1 # filter out only relevant DNSEntrypoints
+        - --provider=ns1
+        - --txt-owner-id=k8gb-{{ .Values.k8gb.clusterGeoTag }}
+        - --policy=sync # enable full synchronization including record removal
+        - --log-level=debug # debug only
+        env:
+        - name: NS1_APIKEY
+          valueFrom:
+            secretKeyRef:
+              name: ns1
+              key: apikey
+      securityContext:
+        fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
+{{ end }}

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -86,3 +86,7 @@ spec:
             - name: ROUTE53_ENABLED
               value: "true"
             {{ end }}
+            {{ if .Values.ns1.enabled }}
+            - name: NS1_ENABLED
+              value: "true"
+            {{ end }}

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -92,3 +92,6 @@ route53:
   enabled: false
   hostedZoneID: ZXXXSSS
   irsaRole: arn:aws:iam::111111:role/external-dns
+
+ns1:
+  enabled: true

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -94,4 +94,4 @@ route53:
   irsaRole: arn:aws:iam::111111:role/external-dns
 
 ns1:
-  enabled: true
+  enabled: false

--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -22,6 +22,8 @@ const (
 	DNSTypeInfoblox
 	// DNSTypeRoute53 type
 	DNSTypeRoute53
+	// DNSTypeNS1 type
+	DNSTypeNS1
 )
 
 // Infoblox configuration
@@ -69,6 +71,8 @@ type Config struct {
 	Override Override
 	// route53Enabled hidden. EdgeDNSType defines all enabled Enabled types
 	route53Enabled bool
+	// ns1Enabled flag
+	ns1Enabled bool
 }
 
 // DependencyResolver resolves configuration for GSLB

--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -12,6 +12,7 @@ const (
 	ClusterGeoTagKey           = "CLUSTER_GEO_TAG"
 	ExtClustersGeoTagsKey      = "EXT_GSLB_CLUSTERS_GEO_TAGS"
 	Route53EnabledKey          = "ROUTE53_ENABLED"
+	NS1EnabledKey              = "NS1_ENABLED"
 	EdgeDNSServerKey           = "EDGE_DNS_SERVER"
 	EdgeDNSZoneKey             = "EDGE_DNS_ZONE"
 	DNSZoneKey                 = "DNS_ZONE"
@@ -34,6 +35,7 @@ func (dr *DependencyResolver) ResolveOperatorConfig() (*Config, error) {
 		dr.config.ClusterGeoTag = env.GetEnvAsStringOrFallback(ClusterGeoTagKey, "")
 		dr.config.ExtClustersGeoTags = env.GetEnvAsArrayOfStringsOrFallback(ExtClustersGeoTagsKey, []string{})
 		dr.config.route53Enabled = env.GetEnvAsBoolOrFallback(Route53EnabledKey, false)
+		dr.config.ns1Enabled = env.GetEnvAsBoolOrFallback(NS1EnabledKey, false)
 		dr.config.EdgeDNSServer = env.GetEnvAsStringOrFallback(EdgeDNSServerKey, "")
 		dr.config.EdgeDNSZone = env.GetEnvAsStringOrFallback(EdgeDNSZoneKey, "")
 		dr.config.DNSZone = env.GetEnvAsStringOrFallback(DNSZoneKey, "")
@@ -110,6 +112,9 @@ func (dr *DependencyResolver) validateConfig(config *Config) (err error) {
 // getEdgeDNSType contains logic retrieving EdgeDNSType
 func getEdgeDNSType(config *Config) EdgeDNSType {
 	var t = DNSTypeNoEdgeDNS
+	if config.ns1Enabled {
+		t |= DNSTypeNS1
+	}
 	if config.route53Enabled {
 		t |= DNSTypeRoute53
 	}

--- a/controllers/depresolver/depresolver_test.go
+++ b/controllers/depresolver/depresolver_test.go
@@ -305,6 +305,40 @@ func TestResolveConfigWithEmptyRoute53(t *testing.T) {
 	assert.Equal(t, false, config.route53Enabled)
 }
 
+func TestResolveConfigWithProperNS1Enabled(t *testing.T) {
+	// arrange
+	defer cleanup()
+	expected := predefinedConfig
+	expected.ns1Enabled = true
+	expected.Infoblox.Host = ""
+	expected.EdgeDNSType = DNSTypeNS1
+	// act,assert
+	arrangeVariablesAndAssert(t, expected, assert.NoError)
+}
+
+func TestResolveConfigWithoutNS1(t *testing.T) {
+	// arrange
+	defer cleanup()
+	expected := predefinedConfig
+	expected.ns1Enabled = false
+	// act,assert
+	arrangeVariablesAndAssert(t, expected, assert.NoError, NS1EnabledKey)
+}
+
+func TestResolveConfigWithEmptyNS1(t *testing.T) {
+	// arrange
+	defer cleanup()
+	configureEnvVar(predefinedConfig)
+	_ = os.Setenv(NS1EnabledKey, "")
+	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
+	resolver := NewDependencyResolver(cl)
+	// act
+	config, err := resolver.ResolveOperatorConfig()
+	// assert
+	assert.NoError(t, err)
+	assert.Equal(t, false, config.ns1Enabled)
+}
+
 func TestResolveConfigWithEmptyEdgeDnsServer(t *testing.T) {
 	// arrange
 	defer cleanup()
@@ -909,6 +943,7 @@ func configureEnvVar(config Config) {
 	_ = os.Setenv(EdgeDNSZoneKey, config.EdgeDNSZone)
 	_ = os.Setenv(DNSZoneKey, config.DNSZone)
 	_ = os.Setenv(Route53EnabledKey, strconv.FormatBool(config.route53Enabled))
+	_ = os.Setenv(NS1EnabledKey, strconv.FormatBool(config.ns1Enabled))
 	_ = os.Setenv(InfobloxGridHostKey, config.Infoblox.Host)
 	_ = os.Setenv(InfobloxVersionKey, config.Infoblox.Version)
 	_ = os.Setenv(InfobloxPortKey, strconv.Itoa(config.Infoblox.Port))

--- a/controllers/dnsupdate.go
+++ b/controllers/dnsupdate.go
@@ -520,9 +520,10 @@ func (r *GslbReconciler) configureZoneDelegation(gslb *k8gbv1beta1.Gslb) (*recon
 				return &reconcile.Result{}, err
 			}
 		}
-
+	case depresolver.DNSTypeNoEdgeDNS:
+		return nil, nil
 	}
-	return nil, nil
+	return nil, coreerrors.New("unhandled DNS type...")
 }
 
 func (r *GslbReconciler) ensureDNSEndpoint(

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -663,7 +663,6 @@ func TestCreatesNSDNSRecordsForRoute53(t *testing.T) {
 	defer cleanup()
 	const dnsZone = "cloud.example.com"
 	const want = "route53"
-	const coreDNSLBServiceName = "k8gb-coredns-lb"
 	wantEp := []*externaldns.Endpoint{
 		{
 			DNSName:    dnsZone,
@@ -690,7 +689,7 @@ func TestCreatesNSDNSRecordsForRoute53(t *testing.T) {
 	customConfig.EdgeDNSServer = "1.1.1.1"
 	coreDNSService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      coreDNSLBServiceName,
+			Name:      coreDNSExtServiceName,
 			Namespace: k8gbNamespace,
 		},
 	}
@@ -699,7 +698,7 @@ func TestCreatesNSDNSRecordsForRoute53(t *testing.T) {
 	}
 	settings := provideSettings(t, customConfig)
 	err := settings.client.Create(context.TODO(), coreDNSService)
-	require.NoError(t, err, "Failed to create testing %s service", coreDNSLBServiceName)
+	require.NoError(t, err, "Failed to create testing %s service", coreDNSExtServiceName)
 	coreDNSService.Status.LoadBalancer.Ingress = append(coreDNSService.Status.LoadBalancer.Ingress, serviceIPs...)
 	err = settings.client.Status().Update(context.TODO(), coreDNSService)
 	require.NoError(t, err, "Failed to update coredns service lb hostname")
@@ -770,12 +769,11 @@ func TestRoute53ZoneDelegationGarbageCollection(t *testing.T) {
 	// arrange
 	defer cleanup()
 
-	const coreDNSLBServiceName = "k8gb-coredns-lb"
 	customConfig := predefinedConfig
 	settings := provideSettings(t, customConfig)
 	coreDNSService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      coreDNSLBServiceName,
+			Name:      coreDNSExtServiceName,
 			Namespace: k8gbNamespace,
 		},
 	}
@@ -783,7 +781,7 @@ func TestRoute53ZoneDelegationGarbageCollection(t *testing.T) {
 		{Hostname: "one.one.one.one"}, // rely on 1.1.1.1 response from Cloudflare
 	}
 	err := settings.client.Create(context.TODO(), coreDNSService)
-	require.NoError(t, err, "Failed to create testing %s service", coreDNSLBServiceName)
+	require.NoError(t, err, "Failed to create testing %s service", coreDNSExtServiceName)
 	coreDNSService.Status.LoadBalancer.Ingress = append(coreDNSService.Status.LoadBalancer.Ingress, serviceIPs...)
 	err = settings.client.Status().Update(context.TODO(), coreDNSService)
 	require.NoError(t, err, "Failed to update coredns service lb hostname")

--- a/docs/deploy_ns1.md
+++ b/docs/deploy_ns1.md
@@ -14,7 +14,7 @@ The EKS setup is identical to [Route53 tutorial](/docs/deploy_route53.md)
 
 Example values.yaml override configs can be found [here](https://github.com/AbsaOSS/k8gb/tree/master/docs/examples/ns1/)
 
-You can use `helm` to deploy stable release from helm repo
+You can use `helm` to deploy stable release from Helm repo
 
 ```sh
 helm repo add k8gb https://www.k8gb.io

--- a/docs/deploy_ns1.md
+++ b/docs/deploy_ns1.md
@@ -1,0 +1,31 @@
+# AWS based deployment with NS1 integration
+
+Here we provide an example of k8gb deployment in AWS context with NS1 as edgeDNS provider
+
+## Reference setup
+
+Two EKS clusters in `eu-west-1` and `us-east-1`.
+
+Terraform code for cluster reference setup can be found [here](https://github.com/AbsaOSS/k8gb/tree/master/docs/examples/route53)
+
+The EKS setup is identical to [Route53 tutorial](/docs/deploy_route53.md)
+
+## Deploy k8gb
+
+Example values.yaml override configs can be found [here](https://github.com/AbsaOSS/k8gb/tree/master/docs/examples/ns1/)
+
+You can use `helm` to deploy stable release from helm repo
+
+```sh
+helm repo add k8gb https://www.k8gb.io
+```
+
+Alternatively, use make target to deploy right from the git repository
+
+```sh
+make deploy-gslb-operator VALUES_YAML=./docs/examples/ns1/k8gb-cluster-ns1-eu-west-1.yaml
+
+#switch kubectl context to us-east-1
+
+make deploy-gslb-operator VALUES_YAML=./docs/examples/ns1/k8gb-cluster-ns1-us-east-1.yaml
+```

--- a/docs/deploy_ns1.md
+++ b/docs/deploy_ns1.md
@@ -12,7 +12,7 @@ The EKS setup is identical to [Route53 tutorial](/docs/deploy_route53.md)
 
 ## Deploy k8gb
 
-Example values.yaml override configs can be found [here](https://github.com/AbsaOSS/k8gb/tree/master/docs/examples/ns1/)
+Example `values.yaml` override configs can be found [here](https://github.com/AbsaOSS/k8gb/tree/master/docs/examples/ns1/)
 
 You can use `helm` to deploy stable release from Helm repo
 

--- a/docs/deploy_route53.md
+++ b/docs/deploy_route53.md
@@ -13,9 +13,9 @@ things like IRSA(IAM Roles for Service Accounts)
 
 ## Deploy k8gb
 
-Example values.yaml override configs can be found [here](https://github.com/AbsaOSS/k8gb/tree/master/docs/examples/route53/k8gb)
+Example `values.yaml` override configs can be found [here](https://github.com/AbsaOSS/k8gb/tree/master/docs/examples/route53/k8gb)
 
-You can use `helm` to deploy stable release from helm repo
+You can use `helm` to deploy stable release from Helm repo
 
 ```sh
 helm repo add k8gb https://www.k8gb.io

--- a/docs/examples/ns1/k8gb-cluster-ns1-eu-west-1.yaml
+++ b/docs/examples/ns1/k8gb-cluster-ns1-eu-west-1.yaml
@@ -1,0 +1,12 @@
+k8gb:
+  dnsZone: "test.k8gb.io" # dnsZone controlled by gslb
+  edgeDNSZone: "k8gb.io" # main zone which would contain gslb zone to delegate
+  edgeDNSServer: "169.254.169.253" # to handle splitbrain situation with TXT timestamp
+  clusterGeoTag: "eu-west-1" # used for places where we need to distinguish between differnet Gslb instances
+  extGslbClustersGeoTags: "us-east-1" # comma-separated list of external gslb geo tags to pair with
+
+externaldns:
+  expose53onWorkers: false # open 53/udp on workers nodes with nginx controller
+
+ns1:
+  enabled: true

--- a/docs/examples/ns1/k8gb-cluster-ns1-us-east-1.yaml
+++ b/docs/examples/ns1/k8gb-cluster-ns1-us-east-1.yaml
@@ -1,0 +1,12 @@
+k8gb:
+  dnsZone: "test.k8gb.io" # dnsZone controlled by gslb
+  edgeDNSZone: "k8gb.io" # main zone which would contain gslb zone to delegate
+  edgeDNSServer: "169.254.169.253" # to handle splitbrain situation with TXT timestamp
+  clusterGeoTag: "us-east-1" # used for places where we need to distinguish between differnet Gslb instances
+  extGslbClustersGeoTags: "eu-west-1" # comma-separated list of external gslb geo tags to pair with
+
+externaldns:
+  expose53onWorkers: false # open 53/udp on workers nodes with nginx controller
+
+ns1:
+  enabled: true


### PR DESCRIPTION
* Chart extension for external-dns based ns1 provider
* Move common code between route53 and NS1(and potentially other providers) to separate function
* Depresolver extension with NS1 provider type
* Depresolver and controller tests
* Chart version bump