### PR TITLE
Switch to new chart repos for dependency charts

### DIFF
--- a/chart/k8gb/Chart.lock
+++ b/chart/k8gb/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: coredns
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.8.4
+  repository: https://coredns.github.io/helm
+  version: 1.14.0
 - name: etcd-operator
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 0.11.0
-digest: sha256:6c29d06119687be6cf485787492891b98b4c518bbe2b208c9e86d122a54c85aa
-generated: "2020-08-06T16:01:59.445384+02:00"
+digest: sha256:a424dc6f1d74fd5aa194629fcccb62a1ee02e9a5317ed20756245e66e80dfe5a
+generated: "2020-12-16T20:55:58.809683+01:00"

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -22,8 +22,8 @@ appVersion: 0.7.2
 
 dependencies:
   - name: coredns
-    repository: https://kubernetes-charts.storage.googleapis.com
-    version: 1.8.4
+    repository: https://coredns.github.io/helm
+    version: 1.14.0
   - name: etcd-operator
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     version: 0.11.0


### PR DESCRIPTION
https://kubernetes-charts.storage.googleapis.com chart mirror
is deprecated and doesn't work anymore.

So we have to switch:

* CoreDNS to the one from https://artifacthub.io/
* etcd-operator to read-only mirror of stable repo