### PR TITLE
Explicit fqdns in roundrobin sample CR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ debug-test-etcd: ## Run temporary etcd pod for debug
 
 .PHONY: demo-roundrobin
 demo-roundrobin: ## Execute round-robin demo
-	@$(call demo-host, "app3.cloud.example.com")
+	@$(call demo-host, "roundrobin.cloud.example.com")
 
 .PHONY: demo-failover
 demo-failover: ## Execute failover demo
@@ -163,7 +163,7 @@ dns-tools: ## Run temporary dnstools pod for debugging DNS issues
 
 .PHONY: dns-smoke-test
 dns-smoke-test:
-	kubectl -n k8gb run -it --rm --restart=Never --image=infoblox/dnstools:latest dnstools --command -- /usr/bin/dig @k8gb-coredns app3.cloud.example.com
+	kubectl -n k8gb run -it --rm --restart=Never --image=infoblox/dnstools:latest dnstools --command -- /usr/bin/dig @k8gb-coredns roundrobin.cloud.example.com
 
 # build the docker image
 .PHONY: docker-build
@@ -251,7 +251,7 @@ test: lint
 
 .PHONY: test-round-robin
 test-round-robin:
-	@$(call hit-testapp-host, "app3.cloud.example.com")
+	@$(call hit-testapp-host, "roundrobin.cloud.example.com")
 
 .PHONY: test-failover
 test-failover:

--- a/controllers/depresolver/testdata/filled_omitempty.yaml
+++ b/controllers/depresolver/testdata/filled_omitempty.yaml
@@ -6,21 +6,21 @@ metadata:
 spec:
   ingress:
     rules:
-      - host: app1.cloud.example.com # This is the GSLB enabled host that clients would use
+      - host: notfound.cloud.example.com # This is the GSLB enabled host that clients would use
         http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
           paths:
             - backend:
                 serviceName: non-existing-app # Gslb should reflect NotFound status
                 servicePort: http
               path: /
-      - host: app2.cloud.example.com
+      - host: unhealthy.cloud.example.com
         http:
           paths:
           - backend:
               serviceName: unhealthy-app # Gslb should reflect Unhealthy status
               servicePort: http
             path: /
-      - host: app3.cloud.example.com
+      - host: roundrobin.cloud.example.com
         http:
           paths:
           - backend:

--- a/controllers/depresolver/testdata/filled_omitempty_with_zero_splitbrain.yaml
+++ b/controllers/depresolver/testdata/filled_omitempty_with_zero_splitbrain.yaml
@@ -6,21 +6,21 @@ metadata:
 spec:
   ingress:
     rules:
-      - host: app1.cloud.example.com # This is the GSLB enabled host that clients would use
+      - host: notfound.cloud.example.com # This is the GSLB enabled host that clients would use
         http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
           paths:
             - backend:
                 serviceName: non-existing-app # Gslb should reflect NotFound status
                 servicePort: http
               path: /
-      - host: app2.cloud.example.com
+      - host: unhealthy.cloud.example.com
         http:
           paths:
           - backend:
               serviceName: unhealthy-app # Gslb should reflect Unhealthy status
               servicePort: http
             path: /
-      - host: app3.cloud.example.com
+      - host: roundrobin.cloud.example.com
         http:
           paths:
           - backend:

--- a/controllers/depresolver/testdata/free_omitempty.yaml
+++ b/controllers/depresolver/testdata/free_omitempty.yaml
@@ -6,21 +6,21 @@ metadata:
 spec:
   ingress:
     rules:
-      - host: app1.cloud.example.com # This is the GSLB enabled host that clients would use
+      - host: notfound.cloud.example.com # This is the GSLB enabled host that clients would use
         http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
           paths:
             - backend:
                 serviceName: non-existing-app # Gslb should reflect NotFound status
                 servicePort: http
               path: /
-      - host: app2.cloud.example.com
+      - host: unhealthy.cloud.example.com
         http:
           paths:
           - backend:
               serviceName: unhealthy-app # Gslb should reflect Unhealthy status
               servicePort: http
             path: /
-      - host: app3.cloud.example.com
+      - host: roundrobin.cloud.example.com
         http:
           paths:
           - backend:

--- a/controllers/depresolver/testdata/invalid_omitempty_empty.yaml
+++ b/controllers/depresolver/testdata/invalid_omitempty_empty.yaml
@@ -6,21 +6,21 @@ metadata:
 spec:
   ingress:
     rules:
-      - host: app1.cloud.example.com # This is the GSLB enabled host that clients would use
+      - host: notfound.cloud.example.com # This is the GSLB enabled host that clients would use
         http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
           paths:
             - backend:
                 serviceName: non-existing-app # Gslb should reflect NotFound status
                 servicePort: http
               path: /
-      - host: app2.cloud.example.com
+      - host: unhealthy.cloud.example.com
         http:
           paths:
           - backend:
               serviceName: unhealthy-app # Gslb should reflect Unhealthy status
               servicePort: http
             path: /
-      - host: app3.cloud.example.com
+      - host: roundrobin.cloud.example.com
         http:
           paths:
           - backend:

--- a/controllers/depresolver/testdata/invalid_omitempty_negative.yaml
+++ b/controllers/depresolver/testdata/invalid_omitempty_negative.yaml
@@ -6,21 +6,21 @@ metadata:
 spec:
   ingress:
     rules:
-      - host: app1.cloud.example.com # This is the GSLB enabled host that clients would use
+      - host: notfound.cloud.example.com # This is the GSLB enabled host that clients would use
         http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
           paths:
             - backend:
                 serviceName: non-existing-app # Gslb should reflect NotFound status
                 servicePort: http
               path: /
-      - host: app2.cloud.example.com
+      - host: unhealthy.cloud.example.com
         http:
           paths:
           - backend:
               serviceName: unhealthy-app # Gslb should reflect Unhealthy status
               servicePort: http
             path: /
-      - host: app3.cloud.example.com
+      - host: roundrobin.cloud.example.com
         http:
           paths:
           - backend:

--- a/controllers/fakedns.go
+++ b/controllers/fakedns.go
@@ -19,9 +19,9 @@ func oldEdgeTimestamp(threshold string) string {
 }
 
 var records = map[string][]string{
-	"localtargets-app3.cloud.example.com.": {"10.1.0.1", "10.1.0.2", "10.1.0.3"},
-	"test-gslb-heartbeat-eu.example.com.":  {oldEdgeTimestamp("10m")},
-	"test-gslb-heartbeat-za.example.com.":  {oldEdgeTimestamp("3m")},
+	"localtargets-roundrobin.cloud.example.com.": {"10.1.0.1", "10.1.0.2", "10.1.0.3"},
+	"test-gslb-heartbeat-eu.example.com.":        {oldEdgeTimestamp("10m")},
+	"test-gslb-heartbeat-za.example.com.":        {oldEdgeTimestamp("3m")},
 }
 
 func parseQuery(m *dns.Msg) {

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -73,7 +73,7 @@ func TestNotFoundServiceStatus(t *testing.T) {
 	defer cleanup()
 	settings := provideSettings(t, predefinedConfig)
 	expectedServiceStatus := "NotFound"
-	notFoundHost := "app1.cloud.example.com"
+	notFoundHost := "notfound.cloud.example.com"
 	// act
 	actualServiceStatus := settings.gslb.Status.ServiceHealth[notFoundHost]
 	// assert
@@ -86,7 +86,7 @@ func TestUnhealthyServiceStatus(t *testing.T) {
 	defer cleanup()
 	settings := provideSettings(t, predefinedConfig)
 	serviceName := "unhealthy-app"
-	unhealthyHost := "app2.cloud.example.com"
+	unhealthyHost := "unhealthy.cloud.example.com"
 	expectedServiceStatus := "Unhealthy"
 	defer deleteUnhealthyService(t, &settings, serviceName)
 	// act
@@ -104,7 +104,7 @@ func TestHealthyServiceStatus(t *testing.T) {
 	settings := provideSettings(t, predefinedConfig)
 	serviceName := "frontend-podinfo"
 	expectedServiceStatus := "Healthy"
-	healthyHost := "app3.cloud.example.com"
+	healthyHost := "roundrobin.cloud.example.com"
 	defer deleteHealthyService(t, &settings, serviceName)
 	createHealthyService(t, &settings, serviceName)
 	reconcileAndUpdateGslb(t, settings)
@@ -257,12 +257,12 @@ func TestGslbCreatesDNSEndpointCRForHealthyIngressHosts(t *testing.T) {
 	dnsEndpoint := &externaldns.DNSEndpoint{}
 	want := []*externaldns.Endpoint{
 		{
-			DNSName:    "localtargets-app3.cloud.example.com",
+			DNSName:    "localtargets-roundrobin.cloud.example.com",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"}},
 		{
-			DNSName:    "app3.cloud.example.com",
+			DNSName:    "roundrobin.cloud.example.com",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"}},
@@ -298,7 +298,7 @@ func TestDNSRecordReflectionInStatus(t *testing.T) {
 	defer cleanup()
 	serviceName := "frontend-podinfo"
 	dnsEndpoint := &externaldns.DNSEndpoint{}
-	want := map[string][]string{"app3.cloud.example.com": {"10.0.0.1", "10.0.0.2", "10.0.0.3"}}
+	want := map[string][]string{"roundrobin.cloud.example.com": {"10.0.0.1", "10.0.0.2", "10.0.0.3"}}
 	ingressIPs := []corev1.LoadBalancerIngress{
 		{IP: "10.0.0.1"},
 		{IP: "10.0.0.2"},
@@ -373,17 +373,17 @@ func TestCanGetExternalTargetsFromK8gbInAnotherLocation(t *testing.T) {
 	serviceName := "frontend-podinfo"
 	want := []*externaldns.Endpoint{
 		{
-			DNSName:    "localtargets-app3.cloud.example.com",
+			DNSName:    "localtargets-roundrobin.cloud.example.com",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"}},
 		{
-			DNSName:    "app3.cloud.example.com",
+			DNSName:    "roundrobin.cloud.example.com",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.1.0.1", "10.1.0.2", "10.1.0.3"}},
 	}
-	hrWant := map[string][]string{"app3.cloud.example.com": {"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.1.0.1", "10.1.0.2", "10.1.0.3"}}
+	hrWant := map[string][]string{"roundrobin.cloud.example.com": {"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.1.0.1", "10.1.0.2", "10.1.0.3"}}
 	ingressIPs := []corev1.LoadBalancerIngress{
 		{IP: "10.0.0.1"},
 		{IP: "10.0.0.2"},
@@ -487,13 +487,13 @@ func TestReturnsOwnRecordsUsingFailoverStrategyWhenPrimary(t *testing.T) {
 	serviceName := "frontend-podinfo"
 	want := []*externaldns.Endpoint{
 		{
-			DNSName:    "localtargets-app3.cloud.example.com",
+			DNSName:    "localtargets-roundrobin.cloud.example.com",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
 		},
 		{
-			DNSName:    "app3.cloud.example.com",
+			DNSName:    "roundrobin.cloud.example.com",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
@@ -542,13 +542,13 @@ func TestReturnsExternalRecordsUsingFailoverStrategy(t *testing.T) {
 	serviceName := "frontend-podinfo"
 	want := []*externaldns.Endpoint{
 		{
-			DNSName:    "localtargets-app3.cloud.example.com",
+			DNSName:    "localtargets-roundrobin.cloud.example.com",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
 		},
 		{
-			DNSName:    "app3.cloud.example.com",
+			DNSName:    "roundrobin.cloud.example.com",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets:    externaldns.Targets{"10.1.0.1", "10.1.0.2", "10.1.0.3"},
@@ -796,12 +796,12 @@ func TestResolvesLoadBalancerHostnameFromIngressStatus(t *testing.T) {
 	serviceName := "frontend-podinfo"
 	want := []*externaldns.Endpoint{
 		{
-			DNSName:    "localtargets-app3.cloud.example.com",
+			DNSName:    "localtargets-roundrobin.cloud.example.com",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets:    externaldns.Targets{"1.0.0.1", "1.1.1.1"}},
 		{
-			DNSName:    "app3.cloud.example.com",
+			DNSName:    "roundrobin.cloud.example.com",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets:    externaldns.Targets{"1.0.0.1", "1.1.1.1"}},

--- a/deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr.yaml
+++ b/deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr.yaml
@@ -6,21 +6,21 @@ metadata:
 spec:
   ingress:
     rules:
-      - host: app1.cloud.example.com # This is the GSLB enabled host that clients would use
+      - host: notfound.cloud.example.com # This is the GSLB enabled host that clients would use
         http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
           paths:
             - backend:
                 serviceName: non-existing-app # Gslb should reflect NotFound status
                 servicePort: http
               path: /
-      - host: app2.cloud.example.com
+      - host: unhealthy.cloud.example.com
         http:
           paths:
           - backend:
               serviceName: unhealthy-app # Gslb should reflect Unhealthy status
               servicePort: http
             path: /
-      - host: app3.cloud.example.com
+      - host: roundrobin.cloud.example.com
         http:
           paths:
           - backend:

--- a/docs/local.md
+++ b/docs/local.md
@@ -67,28 +67,28 @@ eed5a40bbfb6ee97, started, etcd-cluster-xsjmwdkdf8, http://etcd-cluster-xsjmwdkd
 Cluster [test-gslb1](https://github.com/AbsaOSS/k8gb/tree/master/deploy/kind/cluster.yaml) is exposing external DNS on default port `:5053`
 while [test-gslb2](https://github.com/AbsaOSS/k8gb/tree/master/deploy/kind/cluster2.yaml) on port `:5054`.
 ```shell script
-dig @localhost localtargets-app3.cloud.example.com -p 5053 && dig -p 5054 @localhost localtargets-app3.cloud.example.com
+dig @localhost localtargets-roundrobin.cloud.example.com -p 5053 && dig -p 5054 @localhost localtargets-roundrobin.cloud.example.com
 ```
 As expected result you should see **eight A records** divided between nodes of both clusters.
 ```shell script
 ...
 ...
 ;; ANSWER SECTION:
-localtargets-app3.cloud.example.com. 30 IN A    172.16.0.3
-localtargets-app3.cloud.example.com. 30 IN A    172.16.0.4
-localtargets-app3.cloud.example.com. 30 IN A    172.16.0.2
-localtargets-app3.cloud.example.com. 30 IN A    172.16.0.5
+localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.3
+localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.4
+localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.2
+localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.5
 ...
 ...
-localtargets-app3.cloud.example.com. 30 IN A    172.16.0.8
-localtargets-app3.cloud.example.com. 30 IN A    172.16.0.6
-localtargets-app3.cloud.example.com. 30 IN A    172.16.0.7
-localtargets-app3.cloud.example.com. 30 IN A    172.16.0.9
+localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.8
+localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.6
+localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.7
+localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.9
 ```
 Both clusters have [podinfo](https://github.com/stefanprodan/podinfo) installed on the top.
 Run following command and check if you get two json responses.
 ```shell script
-curl localhost:80 -H "Host:app3.cloud.example.com" && curl localhost:81 -H "Host:app3.cloud.example.com"
+curl localhost:80 -H "Host:roundrobin.cloud.example.com" && curl localhost:81 -H "Host:roundrobin.cloud.example.com"
 ```
 
 #### Run integration tests
@@ -112,7 +112,7 @@ make destroy-full-local-setup
 ### Round Robin
 
 Both clusters have [podinfo](https://github.com/stefanprodan/podinfo) installed on the top, where each
-cluster has been tagged to serve a different region. In this demo we will hit podinfo by `wget -qO - app3.cloud.example.com` and depending
+cluster has been tagged to serve a different region. In this demo we will hit podinfo by `wget -qO - roundrobin.cloud.example.com` and depending
 on region will podinfo return **us** or **eu**. In current round robin implementation are IP addresses randomly picked.
 See [Gslb manifest with round robin strategy](https://github.com/AbsaOSS/k8gb/tree/master/deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr.yaml)
 

--- a/terratest/examples/ingress-annotation-failover.yaml
+++ b/terratest/examples/ingress-annotation-failover.yaml
@@ -7,21 +7,21 @@ metadata:
   name: test-gslb-annotation-failover
 spec:
   rules:
-  - host: app1.cloud.example.com
+  - host: notfound.cloud.example.com
     http:
       paths:
       - backend:
           serviceName: non-existing-app
           servicePort: http
         path: /
-  - host: app2.cloud.example.com
+  - host: unhealthy.cloud.example.com
     http:
       paths:
       - backend:
           serviceName: unhealthy-app
           servicePort: http
         path: /
-  - host: app3.cloud.example.com
+  - host: roundrobin.cloud.example.com
     http:
       paths:
       - backend:

--- a/terratest/examples/ingress-annotation-rr.yaml
+++ b/terratest/examples/ingress-annotation-rr.yaml
@@ -6,21 +6,21 @@ metadata:
   name: test-gslb-annotation
 spec:
   rules:
-  - host: app1.cloud.example.com
+  - host: notfound.cloud.example.com
     http:
       paths:
       - backend:
           serviceName: non-existing-app
           servicePort: http
         path: /
-  - host: app2.cloud.example.com
+  - host: unhealthy.cloud.example.com
     http:
       paths:
       - backend:
           serviceName: unhealthy-app
           servicePort: http
         path: /
-  - host: app3.cloud.example.com
+  - host: roundrobin.cloud.example.com
     http:
       paths:
       - backend:

--- a/terratest/examples/roundrobin.yaml
+++ b/terratest/examples/roundrobin.yaml
@@ -5,21 +5,21 @@ metadata:
 spec:
   ingress:
     rules:
-      - host: app1.cloud.example.com # This is the GSLB enabled host that clients would use
+      - host: notfound.cloud.example.com # This is the GSLB enabled host that clients would use
         http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
           paths:
             - backend:
                 serviceName: non-existing-app # Gslb should reflect NotFound status
                 servicePort: http
               path: /
-      - host: app2.cloud.example.com
+      - host: unhealthy.cloud.example.com
         http:
           paths:
           - backend:
               serviceName: unhealthy-app # Gslb should reflect Unhealthy status
               servicePort: http
             path: /
-      - host: app3.cloud.example.com
+      - host: roundrobin.cloud.example.com
         http:
           paths:
           - backend:

--- a/terratest/test/k8gb_basic_app_test.go
+++ b/terratest/test/k8gb_basic_app_test.go
@@ -87,6 +87,6 @@ func TestK8gbBasicAppExample(t *testing.T) {
 
 	k8s.WaitUntilServiceAvailable(t, options, "frontend-podinfo", 60, 1*time.Second)
 
-	assertGslbStatus(t, options, "test-gslb", "app1.cloud.example.com:NotFound app2.cloud.example.com:Unhealthy app3.cloud.example.com:Healthy")
+	assertGslbStatus(t, options, "test-gslb", "notfound.cloud.example.com:NotFound roundrobin.cloud.example.com:Healthy unhealthy.cloud.example.com:Unhealthy")
 
 }

--- a/terratest/test/k8gb_ingress_annotation_failover_test.go
+++ b/terratest/test/k8gb_ingress_annotation_failover_test.go
@@ -41,7 +41,7 @@ func TestK8gbIngressAnnotationFailover(t *testing.T) {
 
 	ingress := k8s.GetIngress(t, options, "test-gslb-annotation-failover")
 	require.Equal(t, ingress.Name, "test-gslb-annotation-failover")
-	assertGslbStatus(t, options, "test-gslb-annotation-failover", "app1.cloud.example.com:NotFound app2.cloud.example.com:NotFound app3.cloud.example.com:NotFound")
+	assertGslbStatus(t, options, "test-gslb-annotation-failover", "notfound.cloud.example.com:NotFound roundrobin.cloud.example.com:NotFound unhealthy.cloud.example.com:NotFound")
 	assertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.type", "failover")
 	assertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.primaryGeoTag", "eu")
 }

--- a/terratest/test/k8gb_ingress_annotation_rr_test.go
+++ b/terratest/test/k8gb_ingress_annotation_rr_test.go
@@ -41,6 +41,6 @@ func TestK8gbIngressAnnotationRR(t *testing.T) {
 
 	ingress := k8s.GetIngress(t, options, "test-gslb-annotation")
 	require.Equal(t, ingress.Name, "test-gslb-annotation")
-	assertGslbStatus(t, options, "test-gslb-annotation", "app1.cloud.example.com:NotFound app2.cloud.example.com:NotFound app3.cloud.example.com:NotFound")
+	assertGslbStatus(t, options, "test-gslb-annotation", "notfound.cloud.example.com:NotFound roundrobin.cloud.example.com:NotFound unhealthy.cloud.example.com:NotFound")
 	assertGslbSpec(t, options, "test-gslb-annotation", ".spec.strategy.type", "roundRobin")
 }


### PR DESCRIPTION
* Main motivation is that `roundrobin.example.com`
is more clear than `app3.example.com` especially in the demo context

* Rename also `app1` and `app2` with their semantic
meanings

* Associated mass rename in docs and tests

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>