### PR TITLE
Refactor #2, Dig 

### DIFF
--- a/controllers/internal/utils/dns.go
+++ b/controllers/internal/utils/dns.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/lixiangzhong/dnsutil"
+)
+
+// Dig retrieves list of tuple <IP address, A record > from edge DNS server for specific FQDN
+func Dig(edgeDNSServer, fqdn string) ([]string, error) {
+	var dig dnsutil.Dig
+	if edgeDNSServer == "" {
+		return nil, fmt.Errorf("empty edgeDNSServer")
+	}
+	err := dig.SetDNS(edgeDNSServer)
+	if err != nil {
+		err = fmt.Errorf("dig error: can't set query dns (%s) with error(%s)", edgeDNSServer, err)
+		return nil, err
+	}
+	a, err := dig.A(fqdn)
+	if err != nil {
+		err = fmt.Errorf("dig error: can't dig fqdn(%s) with error(%s)", fqdn, err)
+		return nil, err
+	}
+	var IPs []string
+	for _, ip := range a {
+		IPs = append(IPs, fmt.Sprint(ip.A))
+	}
+	sort.Strings(IPs)
+	return IPs, nil
+}

--- a/controllers/internal/utils/dns_test.go
+++ b/controllers/internal/utils/dns_test.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidDig(t *testing.T) {
+	// arrange
+	if !connected() {
+		t.Skipf("no connectivity, skipping")
+	}
+	edgeDNSServer := "8.8.8.8"
+	fqdn := "google.com"
+	// act
+	result, err := Dig(edgeDNSServer, fqdn)
+	// assert
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result)
+	assert.NotEmpty(t, result[0])
+}
+
+func TestEmptyFQDNButValidEdgeDNS(t *testing.T) {
+	// arrange
+	if !connected() {
+		t.Skipf("no connectivity, skipping")
+	}
+	edgeDNSServer := "8.8.8.8"
+	fqdn := ""
+	// act
+	result, err := Dig(edgeDNSServer, fqdn)
+	// assert
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestEmptyEdgeDNS(t *testing.T) {
+	// arrange
+	edgeDNSServer := ""
+	fqdn := "whatever"
+	// act
+	result, err := Dig(edgeDNSServer, fqdn)
+	// assert
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestValidEdgeDNSButNonExistingFQDN(t *testing.T) {
+	// arrange
+	edgeDNSServer := "localhost"
+	fqdn := "some-valid-ip-fqdn-123"
+	// act
+	result, err := Dig(edgeDNSServer, fqdn)
+	// assert
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func connected() (ok bool) {
+	res, err := http.Get("http://google.com")
+	if err != nil {
+		return false
+	}
+	return res.Body.Close() == nil
+}


### PR DESCRIPTION
related to #255 

 - Dig implementation moved from controller to `utils`
 - Tests for Dig require internet connection. Skipping tests If no internet connection available.
 - Remove `log.Info()` from dig, instead return extended error
 - call `log.Info()` in caller functions
