### PR TITLE
refactor prettyPrint

### DIFF
--- a/controllers/dnsupdate.go
+++ b/controllers/dnsupdate.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -516,7 +515,7 @@ func (r *GslbReconciler) ensureDNSEndpoint(
 	if err != nil && errors.IsNotFound(err) {
 
 		// Create the DNSEndpoint
-		log.Info(fmt.Sprintf("Creating a new DNSEndpoint:\n %s", prettyPrint(i)))
+		log.Info(fmt.Sprintf("Creating a new DNSEndpoint:\n %s", utils.ToString(i)))
 		err = r.Create(context.TODO(), i)
 
 		if err != nil {
@@ -560,12 +559,4 @@ func overrideWithFakeDNS(fakeDNSEnabled bool, server string) (ns string) {
 		ns = fmt.Sprintf("%s:53", server)
 	}
 	return
-}
-
-func prettyPrint(s interface{}) string {
-	prettyStruct, err := json.MarshalIndent(s, "", "\t")
-	if err != nil {
-		fmt.Println("can't convert struct to json")
-	}
-	return string(prettyStruct)
 }

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -317,8 +317,8 @@ func TestGslbCreatesDNSEndpointCRForHealthyIngressHosts(t *testing.T) {
 	err = settings.client.Get(context.TODO(), settings.request.NamespacedName, dnsEndpoint)
 	require.NoError(t, err, "Failed to load DNS endpoint")
 	got := dnsEndpoint.Spec.Endpoints
-	prettyGot := prettyPrint(got)
-	prettyWant := prettyPrint(want)
+	prettyGot := utils.ToString(got)
+	prettyWant := utils.ToString(want)
 
 	// assert
 	assert.Equal(t, want, got, "got:\n %s DNSEndpoint,\n\n want:\n %s", prettyGot, prettyWant)
@@ -440,8 +440,8 @@ func TestCanGetExternalTargetsFromK8gbInAnotherLocation(t *testing.T) {
 
 	got := dnsEndpoint.Spec.Endpoints
 	hrGot := settings.gslb.Status.HealthyRecords
-	prettyGot := prettyPrint(got)
-	prettyWant := prettyPrint(want)
+	prettyGot := utils.ToString(got)
+	prettyWant := utils.ToString(want)
 
 	// assert
 	assert.Equal(t, want, got, "got:\n %s DNSEndpoint,\n\n want:\n %s", prettyGot, prettyWant)
@@ -561,8 +561,8 @@ func TestReturnsOwnRecordsUsingFailoverStrategyWhenPrimary(t *testing.T) {
 	err = settings.client.Get(context.TODO(), settings.request.NamespacedName, dnsEndpoint)
 	require.NoError(t, err, "Failed to get expected DNSEndpoint")
 	got := dnsEndpoint.Spec.Endpoints
-	prettyGot := prettyPrint(got)
-	prettyWant := prettyPrint(want)
+	prettyGot := utils.ToString(got)
+	prettyWant := utils.ToString(want)
 
 	// assert
 	assert.Equal(t, want, got, "got:\n %s DNSEndpoint,\n\n want:\n %s", prettyGot, prettyWant)
@@ -616,8 +616,8 @@ func TestReturnsExternalRecordsUsingFailoverStrategy(t *testing.T) {
 	err = settings.client.Get(context.TODO(), settings.request.NamespacedName, dnsEndpoint)
 	require.NoError(t, err, "Failed to get expected DNSEndpoint")
 	got := dnsEndpoint.Spec.Endpoints
-	prettyGot := prettyPrint(got)
-	prettyWant := prettyPrint(want)
+	prettyGot := utils.ToString(got)
+	prettyWant := utils.ToString(want)
 
 	// assert
 	assert.Equal(t, want, got, "got:\n %s DNSEndpoint,\n\n want:\n %s", prettyGot, prettyWant)
@@ -747,8 +747,8 @@ func TestCreatesNSDNSRecordsForRoute53(t *testing.T) {
 	require.NoError(t, err, "Failed to get expected DNSEndpoint")
 	got := dnsEndpointRoute53.Annotations["k8gb.absa.oss/dnstype"]
 	gotEp := dnsEndpointRoute53.Spec.Endpoints
-	prettyGot := prettyPrint(gotEp)
-	prettyWant := prettyPrint(wantEp)
+	prettyGot := utils.ToString(gotEp)
+	prettyWant := utils.ToString(wantEp)
 
 	// assert
 	assert.Equal(t, want, got, "got:\n %q annotation value,\n\n want:\n %q", got, want)
@@ -813,8 +813,8 @@ func TestCreatesNSDNSRecordsForNS1(t *testing.T) {
 	require.NoError(t, err, "Failed to get expected DNSEndpoint")
 	got := dnsEndpointNS1.Annotations["k8gb.absa.oss/dnstype"]
 	gotEp := dnsEndpointNS1.Spec.Endpoints
-	prettyGot := prettyPrint(gotEp)
-	prettyWant := prettyPrint(wantEp)
+	prettyGot := utils.ToString(gotEp)
+	prettyWant := utils.ToString(wantEp)
 
 	// assert
 	assert.Equal(t, want, got, "got:\n %q annotation value,\n\n want:\n %q", got, want)
@@ -855,8 +855,8 @@ func TestResolvesLoadBalancerHostnameFromIngressStatus(t *testing.T) {
 	err = settings.client.Get(context.TODO(), settings.request.NamespacedName, dnsEndpoint)
 	require.NoError(t, err, "Failed to get expected DNSEndpoint")
 	got := dnsEndpoint.Spec.Endpoints
-	prettyGot := prettyPrint(got)
-	prettyWant := prettyPrint(want)
+	prettyGot := utils.ToString(got)
+	prettyWant := utils.ToString(want)
 
 	// assert
 	assert.Equal(t, want, got, "got:\n %s DNSEndpoint,\n\n want:\n %s", prettyGot, prettyWant)

--- a/controllers/internal/utils/string.go
+++ b/controllers/internal/utils/string.go
@@ -1,0 +1,21 @@
+// Package utils provides common functionality to gslb controller
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ToString converts type to formatted string. If value is struct, function returns formatted JSON. Function retrieves
+// null for nil pointer references. Function doesn't return error. In case of marshal error it converts with %v formatter
+// Only two possible errors can occur e.g.:
+//	UnsupportedTypeError ToString(make(chan int));
+//	UnsupportedValueError ToString(math.Inf(1));
+//	In both cases function retrieves expected result. The pointer address in the first while "+Inf" in second
+func ToString(v interface{}) string {
+	value, err := json.MarshalIndent(v, "", "\t")
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(value)
+}

--- a/controllers/internal/utils/string_test.go
+++ b/controllers/internal/utils/string_test.go
@@ -1,0 +1,100 @@
+package utils
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatWithStruct(t *testing.T) {
+	// arrange
+	type str struct {
+		Name  string
+		Value int
+	}
+	s := str{"Foo", 007}
+	expected := `{
+	"Name": "Foo",
+	"Value": 7
+}`
+	// act
+	result := ToString(s)
+	// assert
+	assert.Equal(t, expected, result)
+}
+
+func TestFormatWithPrimitiveType(t *testing.T) {
+	// arrange
+	// act
+	result := ToString(true)
+	// assert
+	assert.Equal(t, "true", result)
+}
+
+func TestFormatWithNilPointerReference(t *testing.T) {
+	// arrange
+	type str struct {
+		Name  string
+		Value int
+	}
+	var ptr *str = nil
+	// act
+	result := ToString(ptr)
+	// assert
+	assert.Equal(t, "null", result)
+}
+
+func TestFormatWithCorruptedStructureMetadata(t *testing.T) {
+	// arrange
+	type str struct {
+		Name  string `json:"CorrectName,omitempty"`
+		Value int    `json:"Incorrect,OMtEmpt"`
+	}
+	s := str{"Foo", 007}
+	expected := `{
+	"CorrectName": "Foo",
+	"Incorrect": 7
+}`
+	// act
+	result := ToString(s)
+	// assert
+	assert.Equal(t, expected, result)
+}
+
+func TestFormatWithEmptyStructure(t *testing.T) {
+	// arrange
+	type str struct {
+		Name  string `json:"CorrectName"`
+		Value int    `json:"Incorrect"`
+	}
+	s := str{}
+	expected := `{
+	"CorrectName": "",
+	"Incorrect": 0
+}`
+	// act
+	result := ToString(s)
+	// assert
+	assert.Equal(t, expected, result)
+}
+
+func TestUnsupportedTypeError(t *testing.T) {
+	// arrange
+	c := make(chan int)
+	addr := fmt.Sprintf("%p", c)
+	// act
+	result := ToString(c)
+	// assert
+	assert.Equal(t, addr, result)
+}
+
+func TestUnsupportedValueError(t *testing.T) {
+	// arrange
+	v := math.Inf(1)
+	// act
+	result := ToString(v)
+	// assert
+	assert.Equal(t, "+Inf", result)
+}


### PR DESCRIPTION
 - move prettyPrint to utility package,  rename to  ToString()
 - test coverage
 - Function returns string only. Possible errors covered, see: `TestUnsupportedValueError`,`TestUnsupportedTypeError`

