### PR TITLE
Make CoreDNS exposure controllable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ init-round-robin:
 # creates infoblox secret in current cluster
 .PHONY: infoblox-secret
 infoblox-secret:
-	kubectl -n k8gb create secret generic external-dns \
+	kubectl -n k8gb create secret generic infoblox \
 		--from-literal=EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME=$${WAPI_USERNAME} \
 		--from-literal=EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD=$${WAPI_PASSWORD}
 

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -13,9 +13,9 @@ annotations:
 
 type: application
 
-version: 0.7.2
+version: 0.7.3
 
-appVersion: 0.7.2
+appVersion: 0.7.3
 
 dependencies:
   - name: coredns

--- a/chart/k8gb/templates/coredns-svc.yaml
+++ b/chart/k8gb/templates/coredns-svc.yaml
@@ -1,4 +1,4 @@
-{{ if or .Values.route53.enabled .Values.ns1.enabled }}
+{{ if .Values.k8gb.exposeCoreDNS }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/chart/k8gb/templates/external-dns/external-dns-ns1.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns-ns1.yaml
@@ -23,7 +23,7 @@ spec:
         - --domain-filter={{ .Values.k8gb.edgeDNSZone }} # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
         - --annotation-filter=k8gb.absa.oss/dnstype=ns1 # filter out only relevant DNSEntrypoints
         - --provider=ns1
-        - --txt-owner-id=k8gb-{{ .Values.k8gb.clusterGeoTag }}
+        - --txt-owner-id=k8gb-{{ .Values.k8gb.dnsZone }}-{{ .Values.k8gb.clusterGeoTag }}
         - --policy=sync # enable full synchronization including record removal
         - --log-level=debug # debug only
         env:

--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: external-dns

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -74,12 +74,12 @@ spec:
             - name: EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: external-dns
+                  name: infoblox
                   key: EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
             - name: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: external-dns
+                  name: infoblox
                   key: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
             {{ end }}
             {{ if .Values.route53.enabled }}
@@ -88,5 +88,9 @@ spec:
             {{ end }}
             {{ if .Values.ns1.enabled }}
             - name: NS1_ENABLED
+              value: "true"
+            {{ end }}
+            {{ if .Values.k8gb.exposeCoreDNS }}
+            - name: COREDNS_EXPOSED
               value: "true"
             {{ end }}

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -19,6 +19,7 @@ k8gb:
     hostnames:
      - "gslb-ns-cloud-example-com-us.example.com"
   reconcileRequeueSeconds: 30
+  exposeCoreDNS: false # Create Service type LoadBalancer to expose CoreDNS
 
 externaldns:
   image: k8s.gcr.io/external-dns/external-dns:v0.7.5

--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -75,6 +75,8 @@ type Config struct {
 	route53Enabled bool
 	// ns1Enabled flag
 	ns1Enabled bool
+	// CoreDNSExposed flag
+	CoreDNSExposed bool
 }
 
 // DependencyResolver resolves configuration for GSLB

--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -25,6 +25,7 @@ const (
 	OverrideWithFakeDNSKey  = "OVERRIDE_WITH_FAKE_EXT_DNS"
 	OverrideFakeInfobloxKey = "FAKE_INFOBLOX"
 	K8gbNamespaceKey        = "POD_NAMESPACE"
+	CoreDNSExposedKey       = "COREDNS_EXPOSED"
 )
 
 // ResolveOperatorConfig executes once. It reads operator's configuration
@@ -37,6 +38,7 @@ func (dr *DependencyResolver) ResolveOperatorConfig() (*Config, error) {
 		dr.config.ExtClustersGeoTags = env.GetEnvAsArrayOfStringsOrFallback(ExtClustersGeoTagsKey, []string{})
 		dr.config.route53Enabled = env.GetEnvAsBoolOrFallback(Route53EnabledKey, false)
 		dr.config.ns1Enabled = env.GetEnvAsBoolOrFallback(NS1EnabledKey, false)
+		dr.config.CoreDNSExposed = env.GetEnvAsBoolOrFallback(CoreDNSExposedKey, false)
 		dr.config.EdgeDNSServer = env.GetEnvAsStringOrFallback(EdgeDNSServerKey, "")
 		dr.config.EdgeDNSZone = env.GetEnvAsStringOrFallback(EdgeDNSZoneKey, "")
 		dr.config.DNSZone = env.GetEnvAsStringOrFallback(DNSZoneKey, "")

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -718,6 +718,7 @@ func TestCreatesNSDNSRecordsForRoute53(t *testing.T) {
 	dnsEndpointRoute53 := &externaldns.DNSEndpoint{}
 	customConfig := predefinedConfig
 	customConfig.EdgeDNSServer = "1.1.1.1"
+	customConfig.CoreDNSExposed = true
 	coreDNSService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      coreDNSExtServiceName,
@@ -784,6 +785,7 @@ func TestCreatesNSDNSRecordsForNS1(t *testing.T) {
 	dnsEndpointNS1 := &externaldns.DNSEndpoint{}
 	customConfig := predefinedConfig
 	customConfig.EdgeDNSServer = "1.1.1.1"
+	customConfig.CoreDNSExposed = true
 	coreDNSService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      coreDNSExtServiceName,


### PR DESCRIPTION
* Do not rely on specific environment but allow control over exposure
* Resolve NSServer IP addresses according to the exposure scenario

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>