### PR TITLE
infoblox, extracting HTTPPoolConnections,HTTPRequestTimeout

### DIFF
--- a/chart/k8gb/templates/infoblox-cm.yaml
+++ b/chart/k8gb/templates/infoblox-cm.yaml
@@ -4,6 +4,8 @@ data:
   INFOBLOX_GRID_HOST: {{ quote .Values.infoblox.gridHost }}
   INFOBLOX_WAPI_VERSION: {{ quote .Values.infoblox.wapiVersion }}
   INFOBLOX_WAPI_PORT: {{ quote .Values.infoblox.wapiPort }}
+  INFOBLOX_HTTP_REQUEST_TIMEOUT: {{ quote .Values.infoblox.httpRequestTimeout }}
+  INFOBLOX_HTTP_POOL_CONNECTIONS: {{ quote .Values.infoblox.httpPoolConnections }}
 kind: ConfigMap
 metadata:
   name: infoblox

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -82,6 +82,16 @@ spec:
                 configMapKeyRef:
                   name: infoblox
                   key: INFOBLOX_WAPI_PORT
+            - name: INFOBLOX_HTTP_REQUEST_TIMEOUT
+              valueFrom:
+                configMapKeyRef:
+                  name: infoblox
+                  key: INFOBLOX_HTTP_REQUEST_TIMEOUT
+            - name: INFOBLOX_HTTP_POOL_CONNECTIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: infoblox
+                  key: INFOBLOX_HTTP_POOL_CONNECTIONS
             - name: EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -88,6 +88,8 @@ infoblox:
   wapiVersion: 2.3.1
   wapiPort: 443
   sslVerify: true
+  httpRequestTimeout: 20
+  httpPoolConnections: 10
 
 route53:
   enabled: false

--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -39,6 +39,10 @@ type Infoblox struct {
 	Username string
 	// Password
 	Password string
+	// HTTPRequestTimeout seconds; default = 20
+	HTTPRequestTimeout int
+	// HTTPPoolConnections seconds; default = 10
+	HTTPPoolConnections int
 }
 
 // Override configuration

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -60,11 +60,13 @@ var predefinedConfig = depresolver.Config{
 	DNSZone:                 "cloud.example.com",
 	K8gbNamespace:           "k8gb",
 	Infoblox: depresolver.Infoblox{
-		Host:     "fakeinfoblox.example.com",
-		Username: "foo",
-		Password: "blah",
-		Port:     443,
-		Version:  "0.0.0",
+		Host:                "fakeinfoblox.example.com",
+		Username:            "foo",
+		Password:            "blah",
+		Port:                443,
+		Version:             "0.0.0",
+		HTTPPoolConnections: 20,
+		HTTPRequestTimeout:  10,
 	},
 	Override: depresolver.Override{
 		FakeInfobloxEnabled: true,
@@ -1118,7 +1120,8 @@ func cleanup() {
 	for _, s := range []string{depresolver.ReconcileRequeueSecondsKey, depresolver.ClusterGeoTagKey, depresolver.ExtClustersGeoTagsKey,
 		depresolver.EdgeDNSZoneKey, depresolver.DNSZoneKey, depresolver.EdgeDNSServerKey, depresolver.K8gbNamespaceKey,
 		depresolver.Route53EnabledKey, depresolver.InfobloxGridHostKey, depresolver.InfobloxVersionKey, depresolver.InfobloxPortKey,
-		depresolver.InfobloxUsernameKey, depresolver.InfobloxPasswordKey, depresolver.OverrideWithFakeDNSKey, depresolver.OverrideFakeInfobloxKey} {
+		depresolver.InfobloxUsernameKey, depresolver.InfobloxPasswordKey, depresolver.InfobloxHTTPRequestTimeoutKey,
+		depresolver.InfobloxHTTPPoolConnectionsKey, depresolver.OverrideWithFakeDNSKey, depresolver.OverrideFakeInfobloxKey} {
 		if os.Unsetenv(s) != nil {
 			panic(fmt.Errorf("cleanup %s", s))
 		}
@@ -1139,6 +1142,8 @@ func configureEnvVar(config depresolver.Config) {
 	_ = os.Setenv(depresolver.InfobloxPortKey, strconv.Itoa(config.Infoblox.Port))
 	_ = os.Setenv(depresolver.InfobloxUsernameKey, config.Infoblox.Username)
 	_ = os.Setenv(depresolver.InfobloxPasswordKey, config.Infoblox.Password)
+	_ = os.Setenv(depresolver.InfobloxHTTPRequestTimeoutKey, strconv.Itoa(config.Infoblox.HTTPRequestTimeout))
+	_ = os.Setenv(depresolver.InfobloxHTTPPoolConnectionsKey, strconv.Itoa(config.Infoblox.HTTPPoolConnections))
 	_ = os.Setenv(depresolver.OverrideWithFakeDNSKey, strconv.FormatBool(config.Override.FakeDNSEnabled))
 	_ = os.Setenv(depresolver.OverrideFakeInfobloxKey, strconv.FormatBool(config.Override.FakeInfobloxEnabled))
 }

--- a/controllers/providers/dns/infoblox-ibclient.go
+++ b/controllers/providers/dns/infoblox-ibclient.go
@@ -15,7 +15,7 @@ func (p *InfobloxProvider) infobloxConnection() (*ibclient.ObjectManager, error)
 		Username: p.config.Infoblox.Username,
 		Password: p.config.Infoblox.Password,
 	}
-	transportConfig := ibclient.NewTransportConfig("false", 20, 10)
+	transportConfig := ibclient.NewTransportConfig("false", p.config.Infoblox.HTTPRequestTimeout, p.config.Infoblox.HTTPPoolConnections)
 	requestBuilder := &ibclient.WapiRequestBuilder{}
 	requestor := &ibclient.WapiHttpRequestor{}
 


### PR DESCRIPTION
related to #255

Infoblox admin complains that tremendous amount of requests is killing his poor Infoblox UI.
Within Infoblox connection I found two other properties, which can be parametrised:
 - HTTPPoolConnections 
 - HTTPRequestTimeout 

For that purpose I made following steps:

 - update infoblox connection within infoblox provider
 - introduce new variables to `depresolver` with default values
    - HTTPPoolConnections (default 10,  Higher or equal to zero)
    - HTTPRequestTimeout (default 20, Higher than zero)
 - update depresolver tests
 - update controller tests
 - introduce new variables in `operator.yaml`
 - `infoblox-cm.yaml` and `values.yaml` (demonstrative purpose; `depresolver` can inject the default values)