### PR TITLE
fix dependabot version upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,24 +1,25 @@
 module github.com/AbsaOSS/k8gb
 
-go 1.13
+go 1.15
 
 require (
 	github.com/AbsaOSS/gopkg v0.0.1
 	github.com/ghodss/yaml v1.0.0
-	github.com/go-logr/logr v0.4.0
-	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/infobloxopen/infoblox-go-client v1.1.0
 	github.com/lixiangzhong/dnsutil v0.0.0-20191203032812-75ad39d2945a
 	github.com/miekg/dns v1.1.38
 	github.com/onsi/ginkgo v1.14.2 // indirect
 	github.com/prometheus/client_golang v1.9.0
 	github.com/stretchr/testify v1.7.0
+	sigs.k8s.io/controller-runtime v0.6.4
+	sigs.k8s.io/external-dns v0.7.6
 
-	// operator sdk v0.20.2; always bump together
+	// go-logr group
+	github.com/go-logr/logr v0.4.0
+	github.com/go-logr/zapr v0.4.0 // indirect
+
+	// operator sdk group
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2
-
-	sigs.k8s.io/controller-runtime v0.6.4
-	sigs.k8s.io/external-dns v0.7.6
 )


### PR DESCRIPTION
see #278 for details

 - reated to #277
 - closes #278
 - go 1.15 upgrade in dockerfile and mod file
 - change order of modules to have them grouped
 - ~~dependabot ignores `sigs.k8s.io/controller-runtime`~~
 
