### PR TITLE
Enable docker experimental features in GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_CLI_EXPERIMENTAL: "enabled"
         run: |
           export PATH=~/go/bin:$PATH
           docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"


### PR DESCRIPTION
To work with docker manifest we need to enable experimental feature.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>