### PR TITLE
Switch sed to helm template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,8 @@ deploy-gslb-operator-14:
 .PHONY: deploy-gslb-cr
 deploy-gslb-cr: ## Apply Gslb Custom Resources
 	kubectl apply -f deploy/crds/test-namespace.yaml
-	$(call apply-cr,deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr.yaml)
-	$(call apply-cr,deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr_failover.yaml)
+	$(call apply-cr)
+	$(call apply-cr)
 
 .PHONY: deploy-test-apps
 deploy-test-apps: ## Deploy testing workloads
@@ -332,8 +332,8 @@ define deploy-local-cluster
 
 	@echo "\n$(YELLOW)Deploy GSLB cr $(NC)"
 	kubectl apply -f deploy/crds/test-namespace.yaml
-	$(call apply-cr,deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr.yaml)
-	$(call apply-cr,deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr_failover.yaml)
+	$(call apply-cr)
+	$(call apply-cr)
 
 	@echo "\n$(YELLOW)Deploy test apps $(NC)"
 	$(call deploy-test-apps)
@@ -345,9 +345,8 @@ define deploy-local-cluster
 endef
 
 define apply-cr
-	sed -i 's/cloud\.example\.com/$(GSLB_DOMAIN)/g' "$1"
-	kubectl apply -f "$1"
-	git checkout -- "$1"
+	helm template testdata deploy/crds/testdata --set domain=$(GSLB_DOMAIN) | \
+	kubectl -n test-gslb apply -f -
 endef
 
 define deploy-test-apps

--- a/deploy/crds/testdata/Chart.yaml
+++ b/deploy/crds/testdata/Chart.yaml
@@ -1,0 +1,5 @@
+appVersion: 0.0.0
+chartVersion: 0.0.0
+name: testdata
+version: 0
+description: Gslb test data

--- a/deploy/crds/testdata/templates/k8gb.absa.oss_v1beta1_gslb_cr.yaml
+++ b/deploy/crds/testdata/templates/k8gb.absa.oss_v1beta1_gslb_cr.yaml
@@ -2,25 +2,25 @@ apiVersion: k8gb.absa.oss/v1beta1
 kind: Gslb
 metadata:
   name: test-gslb
-  namespace: test-gslb
 spec:
   ingress:
     rules:
-      - host: notfound.cloud.example.com # This is the GSLB enabled host that clients would use
+      # This is the GSLB enabled host that clients would use
+      - host: notfound.{{ .Values.domain }}
         http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
           paths:
             - backend:
                 serviceName: non-existing-app # Gslb should reflect NotFound status
                 servicePort: http
               path: /
-      - host: unhealthy.cloud.example.com
+      - host: unhealthy.{{ .Values.domain }}
         http:
           paths:
           - backend:
               serviceName: unhealthy-app # Gslb should reflect Unhealthy status
               servicePort: http
             path: /
-      - host: roundrobin.cloud.example.com
+      - host: roundrobin.{{ .Values.domain }}
         http:
           paths:
           - backend:

--- a/deploy/crds/testdata/templates/k8gb.absa.oss_v1beta1_gslb_cr_failover.yaml
+++ b/deploy/crds/testdata/templates/k8gb.absa.oss_v1beta1_gslb_cr_failover.yaml
@@ -2,11 +2,10 @@ apiVersion: k8gb.absa.oss/v1beta1
 kind: Gslb
 metadata:
   name: test-gslb-failover
-  namespace: test-gslb
 spec:
   ingress:
     rules:
-      - host: failover.cloud.example.com
+      - host: failover.{{ .Values.domain }}
         http:
           paths:
           - backend:

--- a/deploy/crds/testdata/values.yaml
+++ b/deploy/crds/testdata/values.yaml
@@ -1,0 +1,1 @@
+domain: cloud.example.com


### PR DESCRIPTION
Wrap gslb test resources with dummy helm, in oder to leverage helm
template engine and get rid of gnused requirement on Mac

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>