### PR TITLE
bump k3d-action to v 1.2.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           destination-repo: absaoss/k8gb
           destination-branch: gh-pages
       - name: Create single node k3s cluster
-        uses: AbsaOSS/k3d-action@v1.1.0
+        uses: AbsaOSS/k3d-action@v1.2.0
         with:
           cluster-name: "test-gslb1"
           use-default-registry: false

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Create 1st k3s Cluster
-        uses: AbsaOSS/k3d-action@v1.1.0
+        uses: AbsaOSS/k3d-action@v1.2.0
         with:
           cluster-name: "test-gslb1"
           use-default-registry: true
@@ -29,7 +29,7 @@ jobs:
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
       - name: Create 2nd k3s Cluster
-        uses: AbsaOSS/k3d-action@v1.1.0
+        uses: AbsaOSS/k3d-action@v1.2.0
         with:
           cluster-name: "test-gslb2"
           use-default-registry: true


### PR DESCRIPTION
bump k3d-action to v 1.2.0

helm requires semantic version format e.g.:`v7.0.4-5346f3e` otherwise helm error:
```
Error: validation: chart.metadata.version "5346f3e" is invalid
```