### PR TITLE
Validate spec.ingress.rules.host

### DIFF
--- a/controllers/depresolver/depresolver_spec.go
+++ b/controllers/depresolver/depresolver_spec.go
@@ -25,7 +25,7 @@ func (dr *DependencyResolver) ResolveGslbSpec(ctx context.Context, gslb *k8gbv1b
 		if strategy.SplitBrainThresholdSeconds == 0 {
 			strategy.SplitBrainThresholdSeconds = predefinedStrategy.SplitBrainThresholdSeconds
 		}
-		dr.errorSpec = dr.validateSpec(strategy)
+		dr.errorSpec = dr.validateStrategy(strategy)
 		if dr.errorSpec == nil {
 			dr.errorSpec = dr.client.Update(ctx, gslb)
 		}
@@ -38,7 +38,7 @@ func (dr *DependencyResolver) ResolveGslbSpec(ctx context.Context, gslb *k8gbv1b
 	return dr.errorSpec
 }
 
-func (dr *DependencyResolver) validateSpec(strategy *k8gbv1beta1.Strategy) (err error) {
+func (dr *DependencyResolver) validateStrategy(strategy *k8gbv1beta1.Strategy) (err error) {
 	err = field("DNSTtlSeconds", strategy.DNSTtlSeconds).isHigherOrEqualToZero().err
 	if err != nil {
 		return

--- a/controllers/depresolver/depresolver_spec.go
+++ b/controllers/depresolver/depresolver_spec.go
@@ -2,6 +2,7 @@ package depresolver
 
 import (
 	"context"
+	"errors"
 
 	k8gbv1beta1 "github.com/AbsaOSS/k8gb/api/v1beta1"
 )
@@ -27,6 +28,11 @@ func (dr *DependencyResolver) ResolveGslbSpec(ctx context.Context, gslb *k8gbv1b
 		dr.errorSpec = dr.validateSpec(strategy)
 		if dr.errorSpec == nil {
 			dr.errorSpec = dr.client.Update(ctx, gslb)
+		}
+		for _, rule := range gslb.Spec.Ingress.Rules {
+			if rule.HTTP == nil {
+				dr.errorSpec = errors.New("missing .spec.ingress.rules.http")
+			}
 		}
 	})
 	return dr.errorSpec

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -91,7 +91,7 @@ func (r *GslbReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	err = r.DepResolver.ResolveGslbSpec(ctx, gslb)
 	if err != nil {
-		log.Error(err, "resolving spec.strategy")
+		log.Error(err, "resolving spec")
 		return ctrl.Result{}, err
 	}
 	// == Finalizer business ==
@@ -190,6 +190,10 @@ func (r *GslbReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			gslbName := ""
 			for _, gslb := range gslbList.Items {
 				for _, rule := range gslb.Spec.Ingress.Rules {
+					if rule.HTTP == nil {
+						log.Info(fmt.Sprintf("spec.ingress.rules.http is missing on %s", gslb.Name))
+						continue
+					}
 					for _, path := range rule.HTTP.Paths {
 						if path.Backend.ServiceName == a.Meta.GetName() {
 							gslbName = gslb.Name

--- a/terratest/test/k8gb_basic_failover_test.go
+++ b/terratest/test/k8gb_basic_failover_test.go
@@ -77,5 +77,4 @@ func TestK8gbBasicFailoverExample(t *testing.T) {
 
 		assert.Equal(t, afterFailoverResponse, expectedIPsAfterFailover)
 	})
-
 }


### PR DESCRIPTION
Since controller relies on it, we need to explicitly require
spec.ingress.rules.http

Fixes https://github.com/AbsaOSS/k8gb/issues/296

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>