### PR TITLE
Infoblox, persistent connection

### DIFF
--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -696,8 +696,8 @@ func TestCreatesNSDNSRecordsForRoute53(t *testing.T) {
 	settings.reconciler.Config = &customConfig
 	// If config is changed, new Route53 provider needs to be re-created. There is no way and reason to change provider
 	// configuration at another time than startup
-	f, _ := dns.NewDNSProviderFactory(settings.reconciler.Client, customConfig, settings.reconciler.Log)
-	settings.reconciler.DNSProvider = f.Provider()
+	f := dns.NewDNSProviderFactory(settings.reconciler.Client, customConfig, settings.reconciler.Log)
+	settings.reconciler.DNSProvider, _ = f.Provider()
 
 	reconcileAndUpdateGslb(t, settings)
 	err = settings.client.Get(context.TODO(), client.ObjectKey{Namespace: predefinedConfig.K8gbNamespace, Name: "k8gb-ns-route53"}, dnsEndpointRoute53)
@@ -767,8 +767,8 @@ func TestCreatesNSDNSRecordsForNS1(t *testing.T) {
 	settings.reconciler.Config = &customConfig
 	// If config is changed, new Route53 provider needs to be re-created. There is no way and reason to change provider
 	// configuration at another time than startup
-	f, _ := dns.NewDNSProviderFactory(settings.reconciler.Client, customConfig, settings.reconciler.Log)
-	settings.reconciler.DNSProvider = f.Provider()
+	f := dns.NewDNSProviderFactory(settings.reconciler.Client, customConfig, settings.reconciler.Log)
+	settings.reconciler.DNSProvider, _ = f.Provider()
 
 	reconcileAndUpdateGslb(t, settings)
 	err = settings.client.Get(context.TODO(), client.ObjectKey{Namespace: predefinedConfig.K8gbNamespace, Name: "k8gb-ns-ns1"}, dnsEndpointNS1)
@@ -1079,12 +1079,11 @@ func provideSettings(t *testing.T, expected depresolver.Config) (settings testSe
 		},
 	}
 
-	var f *dns.ProviderFactory
-	f, err = dns.NewDNSProviderFactory(r.Client, *r.Config, r.Log)
+	f := dns.NewDNSProviderFactory(r.Client, *r.Config, r.Log)
+	r.DNSProvider, err = f.Provider()
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	r.DNSProvider = f.Provider()
 	a := assistant.NewGslbAssistant(r.Client, r.Log, r.Config.K8gbNamespace, r.Config.EdgeDNSServer)
 	res, err := r.Reconcile(req)
 	if err != nil {

--- a/controllers/providers/dns/factory_test.go
+++ b/controllers/providers/dns/factory_test.go
@@ -21,9 +21,9 @@ func TestFactoryInfoblox(t *testing.T) {
 	customConfig := predefinedConfig
 	customConfig.EdgeDNSType = depresolver.DNSTypeInfoblox
 	// act
-	f, err := NewDNSProviderFactory(client, customConfig, log)
+	f := NewDNSProviderFactory(client, customConfig, log)
+	provider, err := f.Provider()
 	require.NoError(t, err)
-	provider := f.Provider()
 	// assert
 	assert.NotNil(t, provider)
 	assert.Equal(t, "*InfobloxProvider", utils.GetType(provider))
@@ -37,9 +37,9 @@ func TestFactoryNS1(t *testing.T) {
 	customConfig := predefinedConfig
 	customConfig.EdgeDNSType = depresolver.DNSTypeNS1
 	// act
-	f, err := NewDNSProviderFactory(client, customConfig, log)
+	f := NewDNSProviderFactory(client, customConfig, log)
+	provider, err := f.Provider()
 	require.NoError(t, err)
-	provider := f.Provider()
 	// assert
 	assert.NotNil(t, provider)
 	assert.Equal(t, "*ExternalDNSProvider", utils.GetType(provider))
@@ -53,9 +53,9 @@ func TestFactoryRoute53(t *testing.T) {
 	customConfig := predefinedConfig
 	customConfig.EdgeDNSType = depresolver.DNSTypeRoute53
 	// act
-	f, err := NewDNSProviderFactory(client, customConfig, log)
+	f := NewDNSProviderFactory(client, customConfig, log)
+	provider, err := f.Provider()
 	require.NoError(t, err)
-	provider := f.Provider()
 	// assert
 	assert.NotNil(t, provider)
 	assert.Equal(t, "*ExternalDNSProvider", utils.GetType(provider))
@@ -69,9 +69,9 @@ func TestFactoryNoEdgeDNS(t *testing.T) {
 	customConfig := predefinedConfig
 	customConfig.EdgeDNSType = depresolver.DNSTypeNoEdgeDNS
 	// act
-	f, err := NewDNSProviderFactory(client, customConfig, log)
+	f := NewDNSProviderFactory(client, customConfig, log)
+	provider, err := f.Provider()
 	require.NoError(t, err)
-	provider := f.Provider()
 	// assert
 	assert.Equal(t, "*EmptyDNSProvider", utils.GetType(provider))
 	assert.Equal(t, "EMPTY", fmt.Sprintf("%s", provider))
@@ -84,7 +84,7 @@ func TestFactoryNilLogger(t *testing.T) {
 	customConfig.EdgeDNSType = depresolver.DNSTypeNoEdgeDNS
 	// act
 	// assert
-	_, err := NewDNSProviderFactory(nil, customConfig, log)
+	_, err := NewDNSProviderFactory(nil, customConfig, log).Provider()
 	require.Error(t, err)
 }
 
@@ -95,6 +95,6 @@ func TestFactoryNilClient(t *testing.T) {
 	customConfig.EdgeDNSType = depresolver.DNSTypeNoEdgeDNS
 	// act
 	// assert
-	_, err := NewDNSProviderFactory(client, customConfig, nil)
+	_, err := NewDNSProviderFactory(client, customConfig, nil).Provider()
 	require.Error(t, err)
 }

--- a/controllers/providers/dns/infoblox_test.go
+++ b/controllers/providers/dns/infoblox_test.go
@@ -3,6 +3,8 @@ package dns
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/AbsaOSS/k8gb/controllers/depresolver"
 	"github.com/AbsaOSS/k8gb/controllers/providers/assistant"
 
@@ -49,7 +51,8 @@ func TestCanFilterOutDelegatedZoneEntryAccordingFQDNProvided(t *testing.T) {
 	customConfig.EdgeDNSZone = "example.com"
 	customConfig.ExtClustersGeoTags = []string{"za"}
 	a := assistant.NewGslbAssistant(nil, nil, customConfig.K8gbNamespace, customConfig.EdgeDNSServer)
-	provider := NewInfobloxDNS(customConfig, a)
+	provider, err := NewInfobloxDNS(customConfig, a)
+	require.NoError(t, err)
 	// act
 	extClusters := nsServerNameExt(customConfig)
 	got := provider.filterOutDelegateTo(delegateTo, extClusters[0])

--- a/main.go
+++ b/main.go
@@ -99,12 +99,12 @@ func main() {
 		setupLog.Error(err, "reading config env variables")
 	}
 	setupLog.Info("starting DNS provider")
-	f, err = dns.NewDNSProviderFactory(reconciler.Client, *reconciler.Config, reconciler.Log)
+	f = dns.NewDNSProviderFactory(reconciler.Client, *reconciler.Config, reconciler.Log)
+	reconciler.DNSProvider, err = f.Provider()
 	if err != nil {
-		setupLog.Error(err, "unable to create factory (%s)", err)
+		setupLog.Error(err, "unable to create provider (%s)", err)
 		os.Exit(1)
 	}
-	reconciler.DNSProvider = f.Provider()
 	setupLog.Info(fmt.Sprintf("provider: %s", reconciler.DNSProvider))
 	setupLog.Info("starting metrics")
 	reconciler.Metrics = metrics.NewPrometheusMetrics(*reconciler.Config)


### PR DESCRIPTION
 - connection is created only once in Infoblox constructor function
 - provider constructor function is returning errors, so changing tests and factory
 - tested with @somaritane, @k0da  against `k8gb-test-nonprod-sdc`
 