### PR TITLE
Sort externalTargets queried from DNS

### DIFF
--- a/controllers/dnsupdate.go
+++ b/controllers/dnsupdate.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	k8gbv1beta1 "github.com/AbsaOSS/k8gb/api/v1beta1"
@@ -10,6 +11,12 @@ import (
 	externaldns "sigs.k8s.io/external-dns/endpoint"
 )
 
+func sortTargets(targets []string) []string {
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i] < targets[j]
+	})
+	return targets
+}
 func (r *GslbReconciler) gslbDNSEndpoint(gslb *k8gbv1beta1.Gslb) (*externaldns.DNSEndpoint, error) {
 	var gslbHosts []*externaldns.Endpoint
 	var ttl = externaldns.TTL(gslb.Spec.Strategy.DNSTtlSeconds)
@@ -45,6 +52,8 @@ func (r *GslbReconciler) gslbDNSEndpoint(gslb *k8gbv1beta1.Gslb) (*externaldns.D
 
 		// Check if host is alive on external Gslb
 		externalTargets := r.DNSProvider.GetExternalTargets(host)
+
+		sortTargets(externalTargets)
 
 		if len(externalTargets) > 0 {
 			switch gslb.Spec.Strategy.Type {

--- a/controllers/fakedns.go
+++ b/controllers/fakedns.go
@@ -19,7 +19,7 @@ func oldEdgeTimestamp(threshold string) string {
 }
 
 var records = map[string][]string{
-	"localtargets-roundrobin.cloud.example.com.": {"10.1.0.1", "10.1.0.2", "10.1.0.3"},
+	"localtargets-roundrobin.cloud.example.com.": {"10.1.0.3", "10.1.0.2", "10.1.0.1"},
 	"test-gslb-heartbeat-eu.example.com.":        {oldEdgeTimestamp("10m")},
 	"test-gslb-heartbeat-za.example.com.":        {oldEdgeTimestamp("3m")},
 }


### PR DESCRIPTION
In case CoreDNS runs with loadbalancer round_robin plugin enabled, k8gb
controller gets shuffled results while computing externalTarget list.
This leads to DNSEndpoint object update despite the fact list is the
same. Lets make list sorted and reproducible to avoid unnescessary
reconcilation loops.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>