### PR TITLE
Validate spec.ingress.http.path

### DIFF
--- a/chart/k8gb/crds/k8gb.absa.oss_gslbs_crd.yaml
+++ b/chart/k8gb/crds/k8gb.absa.oss_gslbs_crd.yaml
@@ -65,6 +65,8 @@ spec:
                       under a specified host to the related backend services. Incoming
                       requests are first evaluated for a host match, then routed to
                       the backend associated with the matching IngressRuleValue.
+                    required:
+                    - "http"
                     properties:
                       host:
                         description: "Host is the fully qualified domain name of a
@@ -85,6 +87,8 @@ spec:
                           -> backend where where parts of the url correspond to RFC
                           3986, this resource will be used to match against everything
                           after the last ''/'' and before the first ''?'' or ''#''.'
+                        required:
+                        - "paths"
                         properties:
                           paths:
                             description: A collection of paths that map requests to

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -257,7 +257,10 @@ func (r *GslbReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 
 		log.Info(fmt.Sprintf("Creating new Gslb(%s) out of Ingress annotation", gslb.Name))
-		_ = c.Create(context.Background(), gslb)
+		err = c.Create(context.Background(), gslb)
+		if err != nil {
+			log.Error(err, "Glsb creation failed")
+		}
 	}
 	ingressMapFn := handler.ToRequestsFunc(
 		func(a handler.MapObject) []reconcile.Request {

--- a/deploy/crds/k8gb.absa.oss_gslbs_crd.yaml
+++ b/deploy/crds/k8gb.absa.oss_gslbs_crd.yaml
@@ -65,6 +65,8 @@ spec:
                       under a specified host to the related backend services. Incoming
                       requests are first evaluated for a host match, then routed to
                       the backend associated with the matching IngressRuleValue.
+                    required:
+                    - "http"
                     properties:
                       host:
                         description: "Host is the fully qualified domain name of a
@@ -85,6 +87,8 @@ spec:
                           -> backend where where parts of the url correspond to RFC
                           3986, this resource will be used to match against everything
                           after the last ''/'' and before the first ''?'' or ''#''.'
+                        required:
+                        - "paths"
                         properties:
                           paths:
                             description: A collection of paths that map requests to

--- a/terratest/examples/broken-gslb-no-http.yaml
+++ b/terratest/examples/broken-gslb-no-http.yaml
@@ -1,0 +1,11 @@
+apiVersion: k8gb.absa.oss/v1beta1
+kind: Gslb
+metadata:
+  name: broken-test-gslb1
+spec:
+  ingress:
+    rules:
+      - host: terratest-failover.cloud.example.com
+  strategy:
+    type: failover
+    primaryGeoTag: eu

--- a/terratest/examples/broken-gslb.yaml
+++ b/terratest/examples/broken-gslb.yaml
@@ -1,0 +1,17 @@
+apiVersion: k8gb.absa.oss/v1beta1
+kind: Gslb
+metadata:
+  name: broken-test-gslb1
+spec:
+  ingress:
+    rules:
+      - host: terratest-failover.cloud.example.com
+        https:
+          paths:
+          - backend:
+              serviceName: frontend-podinfo # Gslb should reflect Healthy status and create associated DNS records
+              servicePort: http
+            path: /
+  strategy:
+    type: failover
+    primaryGeoTag: eu

--- a/terratest/examples/broken-ingress-annotation.yaml
+++ b/terratest/examples/broken-ingress-annotation.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    k8gb.io/strategy: failover
+    k8gb.io/primary-geotag: eu
+  name: broken-test-gslb-annotation-failover
+spec:
+  rules:
+  - host: notfound.cloud.example.com
+    #http:
+    #  paths:
+    #  - backend:
+    #      serviceName: non-existing-app
+    #      servicePort: http
+    #    path: /

--- a/terratest/test/k8gb_basic_app_test.go
+++ b/terratest/test/k8gb_basic_app_test.go
@@ -26,6 +26,11 @@ func TestK8gbBasicAppExample(t *testing.T) {
 	kubeResourcePath, err := filepath.Abs("../examples/roundrobin.yaml")
 	require.NoError(t, err)
 
+	brokenResourcePath, err := filepath.Abs("../examples/broken-gslb.yaml")
+	require.NoError(t, err)
+	brokenNoHTTPResourcePath, err := filepath.Abs("../examples/broken-gslb-no-http.yaml")
+	require.NoError(t, err)
+
 	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
 	// namespace for the resources for this test.
 	// Note that namespaces must be lowercase.
@@ -90,5 +95,12 @@ func TestK8gbBasicAppExample(t *testing.T) {
 	assertGslbStatus(t, options, "test-gslb", "notfound.cloud.example.com:NotFound roundrobin.cloud.example.com:Healthy unhealthy.cloud.example.com:Unhealthy")
 	// Ensure controller labels DNSEndpoint objects
 	assertDNSEndpointLabel(t, options, "k8gb.absa.oss/dnstype")
+
+	t.Run("Broken object rejected by API", func(t *testing.T) {
+		err := k8s.KubectlApplyE(t, options, brokenResourcePath)
+		require.Error(t, err)
+		err = k8s.KubectlApplyE(t, options, brokenNoHTTPResourcePath)
+		require.Error(t, err)
+	})
 
 }

--- a/terratest/test/k8gb_ingress_annotation_failover_test.go
+++ b/terratest/test/k8gb_ingress_annotation_failover_test.go
@@ -19,6 +19,8 @@ func TestK8gbIngressAnnotationFailover(t *testing.T) {
 	// Path to the Kubernetes resource config we will test
 	kubeResourcePath, err := filepath.Abs("../examples/ingress-annotation-failover.yaml")
 	require.NoError(t, err)
+	brokenResourcePath, err := filepath.Abs("../examples/broken-ingress-annotation.yaml")
+	require.NoError(t, err)
 
 	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
 	// namespace for the resources for this test.
@@ -44,4 +46,10 @@ func TestK8gbIngressAnnotationFailover(t *testing.T) {
 	assertGslbStatus(t, options, "test-gslb-annotation-failover", "notfound.cloud.example.com:NotFound roundrobin.cloud.example.com:NotFound unhealthy.cloud.example.com:NotFound")
 	assertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.type", "failover")
 	assertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.primaryGeoTag", "eu")
+
+	t.Run ("Broken ingress is not proccessed", func(t *testing.T) {
+		k8s.KubectlApply(t, options, brokenResourcePath)
+		err := k8s.RunKubectlE(t, options, "get", "gslb","broken-test-gslb-annotation-failover")
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
Require .spec.ingress.http.path as it is required for gslb to function.
If broken Gslb submitted, it will be rejected by openapi v3 validation.
Same will happen when using Ingress annotations, we won't create broken
Gslb object but log an error message instead.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>