### PR TITLE
disable CoreDNS cache

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -39,8 +39,6 @@ coredns:
     - zone: .
     port: 53
     plugins:
-    - name: cache
-      parameters: 30
     - name: errors
     # Serves a /health endpoint on :8080, required for livenessProbe
     - name: health


### PR DESCRIPTION
cache plugin requires TTL to be set, which overrides TTL of a served
entry. In k8gb setup we allow dnsTTLSeconds to be set throguh gslb spec,
witch cache enabled, setting will be ignored.

See: https://coredns.io/plugins/cache/

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>