### PR TITLE
Fix #317, depresolver load new values when GSLB recreated

### DIFF
--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -9,6 +9,8 @@ package depresolver
 import (
 	"sync"
 
+	"github.com/AbsaOSS/k8gb/api/v1beta1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -88,9 +90,9 @@ type DependencyResolver struct {
 	client      client.Client
 	config      *Config
 	onceConfig  sync.Once
-	onceSpec    sync.Once
 	errorConfig error
 	errorSpec   error
+	spec        v1beta1.GslbSpec
 }
 
 // NewDependencyResolver returns a new depresolver.DependencyResolver

--- a/controllers/depresolver/depresolver_spec.go
+++ b/controllers/depresolver/depresolver_spec.go
@@ -2,6 +2,7 @@ package depresolver
 
 import (
 	"context"
+	"reflect"
 
 	k8gbv1beta1 "github.com/AbsaOSS/k8gb/api/v1beta1"
 )
@@ -11,28 +12,27 @@ var predefinedStrategy = k8gbv1beta1.Strategy{
 	SplitBrainThresholdSeconds: 300,
 }
 
-// ResolveGslbSpec executes once during reconciliation. At first cycle it reads
-// omitempty properties and attach predefined values in case they are not defined.
-// ResolveGslbSpec returns error if any input is invalid
+// ResolveGslbSpec fills Gslb by spec values. It executes always, when gslb is initialised.
+// If spec value is not defined, it will use the default value. Function returns error if input is invalid.
 func (dr *DependencyResolver) ResolveGslbSpec(ctx context.Context, gslb *k8gbv1beta1.Gslb) error {
-	dr.onceSpec.Do(func() {
-		strategy := &gslb.Spec.Strategy
+	if !reflect.DeepEqual(gslb.Spec, dr.spec) {
 		// set predefined values if missing in the yaml
-		if strategy.DNSTtlSeconds == 0 {
-			strategy.DNSTtlSeconds = predefinedStrategy.DNSTtlSeconds
+		if gslb.Spec.Strategy.DNSTtlSeconds == 0 {
+			gslb.Spec.Strategy.DNSTtlSeconds = predefinedStrategy.DNSTtlSeconds
 		}
-		if strategy.SplitBrainThresholdSeconds == 0 {
-			strategy.SplitBrainThresholdSeconds = predefinedStrategy.SplitBrainThresholdSeconds
+		if gslb.Spec.Strategy.SplitBrainThresholdSeconds == 0 {
+			gslb.Spec.Strategy.SplitBrainThresholdSeconds = predefinedStrategy.SplitBrainThresholdSeconds
 		}
-		dr.errorSpec = dr.validateSpec(strategy)
+		dr.errorSpec = dr.validateSpec(gslb.Spec.Strategy)
 		if dr.errorSpec == nil {
 			dr.errorSpec = dr.client.Update(ctx, gslb)
 		}
-	})
+		dr.spec = gslb.Spec
+	}
 	return dr.errorSpec
 }
 
-func (dr *DependencyResolver) validateSpec(strategy *k8gbv1beta1.Strategy) (err error) {
+func (dr *DependencyResolver) validateSpec(strategy k8gbv1beta1.Strategy) (err error) {
 	err = field("DNSTtlSeconds", strategy.DNSTtlSeconds).isHigherOrEqualToZero().err
 	if err != nil {
 		return

--- a/controllers/depresolver/depresolver_test.go
+++ b/controllers/depresolver/depresolver_test.go
@@ -102,19 +102,21 @@ func TestResolveSpecWithNegativeFields(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestSpecRunOnce(t *testing.T) {
+func TestSpecRunWhenChanged(t *testing.T) {
 	// arrange
 	cl, gslb := getTestContext("./testdata/filled_omitempty.yaml")
 	ctx := context.Background()
 	resolver := NewDependencyResolver(cl)
 	// act
 	err1 := resolver.ResolveGslbSpec(ctx, gslb)
-	gslb.Spec.Strategy.DNSTtlSeconds = -100
+	gslb.Spec.Strategy.SplitBrainThresholdSeconds = 0
 	err2 := resolver.ResolveGslbSpec(ctx, gslb)
 	// assert
 	assert.NoError(t, err1)
 	// err2 would not be empty
 	assert.NoError(t, err2)
+	assert.Equal(t, predefinedStrategy.SplitBrainThresholdSeconds, gslb.Spec.Strategy.SplitBrainThresholdSeconds)
+	assert.Equal(t, 35, gslb.Spec.Strategy.DNSTtlSeconds)
 }
 
 func TestResolveConfigWithMultipleInvalidEnv(t *testing.T) {

--- a/terratest/examples/failover-spec.yaml
+++ b/terratest/examples/failover-spec.yaml
@@ -1,0 +1,19 @@
+apiVersion: k8gb.absa.oss/v1beta1
+kind: Gslb
+metadata:
+  name: test-gslb-failover-simple
+spec:
+  ingress:
+    rules:
+      - host: terratest-failover.cloud.example.com
+        http:
+          paths:
+          - backend:
+              serviceName: frontend-podinfo # Gslb should reflect Healthy status and create associated DNS records
+              servicePort: http
+            path: /
+  strategy:
+    type: failover
+    primaryGeoTag: eu
+    splitBrainThresholdSeconds: 600
+    dnsTtlSeconds:  60

--- a/terratest/examples/ingress-annotation-failover-simple.yaml
+++ b/terratest/examples/ingress-annotation-failover-simple.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-gslb-failover-simple
+  annotations:
+    k8gb.io/strategy: failover
+    k8gb.io/primary-geotag: "eu"
+spec:
+  rules:
+    - host: failover.cloud.example.com
+      http:
+        paths:
+          - backend:
+              serviceName: frontend-podinfo # Service name to enable GSLB for
+              servicePort: http
+            path: /

--- a/terratest/test/helpers.go
+++ b/terratest/test/helpers.go
@@ -150,4 +150,3 @@ func assertDNSEndpointLabel(t *testing.T, options *k8s.KubectlOptions, label str
 	t.Helper()
 	k8s.RunKubectl(t, options, "get", "dnsendpoint", "-l", label)
 }
-

--- a/terratest/test/k8gb_ingress_annotation_failover_test.go
+++ b/terratest/test/k8gb_ingress_annotation_failover_test.go
@@ -47,9 +47,9 @@ func TestK8gbIngressAnnotationFailover(t *testing.T) {
 	assertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.type", "failover")
 	assertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.primaryGeoTag", "eu")
 
-	t.Run ("Broken ingress is not proccessed", func(t *testing.T) {
+	t.Run("Broken ingress is not proccessed", func(t *testing.T) {
 		k8s.KubectlApply(t, options, brokenResourcePath)
-		err := k8s.RunKubectlE(t, options, "get", "gslb","broken-test-gslb-annotation-failover")
+		err := k8s.RunKubectlE(t, options, "get", "gslb", "broken-test-gslb-annotation-failover")
 		require.Error(t, err)
 	})
 }

--- a/terratest/test/k8gb_lifecycle_test.go
+++ b/terratest/test/k8gb_lifecycle_test.go
@@ -1,0 +1,129 @@
+package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	//k8gbv1beta1 "github.com/AbsaOSS/k8gb/api/v1beta1"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+)
+
+// TestK8gbRepeatedlyRecreatedFromIngress creates GSLB, than keeps operator live and than recreates GSLB again from Ingress.
+// This is usual lifecycle scenario and we are testing spec strategy has expected values.
+func TestK8gbRepeatedlyRecreatedFromIngress(t *testing.T) {
+	t.Parallel()
+	// name of ingress and gslb
+	const name = "test-gslb-failover-simple"
+
+	assertStrategy := func(t *testing.T, options *k8s.KubectlOptions) {
+		assertGslbSpec(t, options, name, "spec.strategy.splitBrainThresholdSeconds", "300")
+		assertGslbSpec(t, options, name, "spec.strategy.dnsTtlSeconds", "30")
+		assertGslbSpec(t, options, name, "spec.strategy.primaryGeoTag", "eu")
+		assertGslbSpec(t, options, name, "spec.strategy.type", "failover")
+	}
+
+	// Path to the Kubernetes resource config we will test
+	ingressResourcePath, err := filepath.Abs("../examples/ingress-annotation-failover-simple.yaml")
+	require.NoError(t, err)
+
+	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
+	// namespace for the resources for this test.
+	// Note that namespaces must be lowercase.
+	namespaceName := fmt.Sprintf("k8gb-basic-example-%s", strings.ToLower(random.UniqueId()))
+
+	// Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	// - Random namespace
+	options := k8s.NewKubectlOptions("", "", namespaceName)
+
+	k8s.CreateNamespace(t, options, namespaceName)
+
+	defer k8s.DeleteNamespace(t, options, namespaceName)
+
+	defer k8s.KubectlDelete(t, options, ingressResourcePath)
+
+	k8s.KubectlApply(t, options, ingressResourcePath)
+
+	k8s.WaitUntilIngressAvailable(t, options, name, 60, 1*time.Second)
+
+	ingress := k8s.GetIngress(t, options, name)
+
+	require.Equal(t, ingress.Name, name)
+
+	// assert Gslb strategy has expected values
+	assertStrategy(t, options)
+
+	k8s.KubectlDelete(t, options, ingressResourcePath)
+
+	err = k8s.RunKubectlE(t, options, "delete", "gslb", name)
+
+	require.NoError(t, err)
+
+	// recreate ingress
+	k8s.KubectlApply(t, options, ingressResourcePath)
+
+	k8s.WaitUntilIngressAvailable(t, options, name, 60, 1*time.Second)
+
+	ingress = k8s.GetIngress(t, options, name)
+
+	require.Equal(t, ingress.Name, name)
+	// assert Gslb strategy has expected values
+	assertStrategy(t, options)
+}
+
+// TestK8gbSpecKeepsStableAfterIngressUpdates, If ingress is updated and GSLB has non default values, the GSLB stays
+// stable and is not updated.
+func TestK8gbSpecKeepsStableAfterIngressUpdates(t *testing.T) {
+	t.Parallel()
+	// name of ingress and gslb
+	const name = "test-gslb-failover-simple"
+
+	assertStrategy := func(t *testing.T, options *k8s.KubectlOptions) {
+		assertGslbSpec(t, options, name, "spec.strategy.splitBrainThresholdSeconds", "600")
+		assertGslbSpec(t, options, name, "spec.strategy.dnsTtlSeconds", "60")
+		assertGslbSpec(t, options, name, "spec.strategy.primaryGeoTag", "eu")
+		assertGslbSpec(t, options, name, "spec.strategy.type", "failover")
+	}
+
+
+	kubeResourcePath, err := filepath.Abs("../examples/failover-spec.yaml")
+	ingressResourcePath, err := filepath.Abs("../examples/ingress-annotation-failover.yaml")
+	require.NoError(t, err)
+	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
+	// namespace for the resources for this test.
+	// Note that namespaces must be lowercase.
+	namespaceName := fmt.Sprintf("k8gb-test-%s", strings.ToLower(random.UniqueId()))
+
+	// Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	// - Random namespace
+	options := k8s.NewKubectlOptions("", "", namespaceName)
+
+	k8s.CreateNamespace(t, options, namespaceName)
+	defer k8s.DeleteNamespace(t, options, namespaceName)
+
+	// create gslb
+	k8s.KubectlApply(t, options, kubeResourcePath)
+	k8s.WaitUntilIngressAvailable(t, options, name, 60, 1*time.Second)
+
+	assertStrategy(t, options)
+
+	// reapply ingress
+	k8s.KubectlApply(t, options, ingressResourcePath)
+
+	k8s.WaitUntilIngressAvailable(t, options, name, 60, 1*time.Second)
+
+	ingress := k8s.GetIngress(t, options, name)
+
+	require.Equal(t, ingress.Name, name)
+	// assert Gslb strategy has initial values, ingress doesn't change it
+	assertStrategy(t, options)
+}


### PR DESCRIPTION
closes #317

depresolver updates itself when gslb changed
  - verified by terratest
  - because functionality changed, I had to fix unit-tests
  - `goimports -w ./` pushed me to minor changes over terratests