### PR TITLE
Update absaoss/k8s_crd CoreDNS plugin to v0.0.2

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -30,7 +30,7 @@ coredns:
   isClusterService: false
   image:
     repository: absaoss/k8s_crd
-    tag: "v0.0.1"
+    tag: "v0.0.2"
   serviceAccount:
     create: true
     name: coredns


### PR DESCRIPTION
This brings RecortTTL and aarch64 architecture support
(absaoss/k8s_crd:v0.0.2)