### PR TITLE
Solve fsGroup issue

### DIFF
--- a/chart/k8gb/templates/external-dns/external-dns-ns1.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns-ns1.yaml
@@ -15,6 +15,10 @@ spec:
         app: external-dns-ns1
     spec:
       serviceAccountName: external-dns
+      securityContext:
+        fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
+        runAsUser: 1000
+        runAsNonRoot: true
       containers:
       - name: external-dns
         image: {{ .Values.externaldns.image }}
@@ -41,8 +45,5 @@ spec:
             memory: "128Mi"
             cpu: "500m"
         securityContext:
-          runAsUser: 1000
-          runAsNonRoot: true
           readOnlyRootFilesystem: true
-          fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
 {{ end }}

--- a/chart/k8gb/templates/external-dns/external-dns-route53.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns-route53.yaml
@@ -15,6 +15,7 @@ spec:
         app: external-dns-route53
     spec:
       serviceAccountName: external-dns
+      securityContext: {{- toYaml .Values.externaldns.securityContext | nindent 8 }}
       containers:
       - name: external-dns
         image: {{ .Values.externaldns.image }}
@@ -35,8 +36,5 @@ spec:
             memory: "128Mi"
             cpu: "500m"
         securityContext:
-          fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
-          runAsUser: 1000
-          runAsNonRoot: true
           readOnlyRootFilesystem: true
 {{ end }}

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -25,6 +25,10 @@ externaldns:
   image: k8s.gcr.io/external-dns/external-dns:v0.7.6
   interval: "20s"
   expose53onWorkers: true # open 53/udp on workers nodes with nginx controller
+  securityContext:
+    fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
+    runAsUser: 1000
+    runAsNonRoot: true
 
 coredns:
   isClusterService: false


### PR DESCRIPTION
* Respect recent api changes and move most of securityContext to pod level,
  only readOnlyRootFilesystem is stayed on container one

* Solves
```
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0].securityContext): unknown field "fsGroup" in io.k8s.api.core.v1.SecurityContext
```
on eks reference deployment

* Fixes #293

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>