### PR TITLE
Bring back external-dns service account

### DIFF
--- a/chart/k8gb/templates/external-dns/rbac.yaml
+++ b/chart/k8gb/templates/external-dns/rbac.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: ["externaldns.k8s.io"]
+  resources: ["dnsendpoints"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["externaldns.k8s.io"]
+  resources: ["dnsendpoints/status"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: {{ .Release.Namespace }}
+{{ if .Values.route53.enabled }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.route53.irsaRole }}
+{{ end }}

--- a/chart/k8gb/templates/external-dns/service-account.yaml
+++ b/chart/k8gb/templates/external-dns/service-account.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: external-dns
-  namespace: {{ .Release.Namespace }}
-{{ if .Values.route53.enabled }}
-  annotations:
-    eks.amazonaws.com/role-arn: {{ .Values.route53.irsaRole }}
-{{ end }}

--- a/chart/k8gb/templates/external-dns/service-account.yaml
+++ b/chart/k8gb/templates/external-dns/service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: {{ .Release.Namespace }}
+{{ if .Values.route53.enabled }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.route53.irsaRole }}
+{{ end }}


### PR DESCRIPTION
During CoreDNS refactor https://github.com/AbsaOSS/k8gb/pull/292
local external-dns instance was removed, while Route53 and NS1
external-dns instances relies on service account created by local
instance. This commit brings back external-dns service account.

Fixes: https://github.com/AbsaOSS/k8gb/issues/328

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>