### PR TITLE
Make k8gb demo curl script ready for local invocation

### DIFF
--- a/deploy/test-apps/curldemo/k8gbcurl.sh
+++ b/deploy/test-apps/curldemo/k8gbcurl.sh
@@ -4,10 +4,16 @@
 # $1 - nameserver to use usually k8gb-coredns service ip
 # $2 - test fqdn to resolve in demo loops
 
-echo "nameserver $1" > /etc/resolv.conf
+if [ "$1" != '--local' ]
+then
+    echo "nameserver $1" > /etc/resolv.conf
+fi
+
+fqdn="$2"
+
 while true
 do
-  curl -s -w "%{stderr}\n%{http_code}\n" --location --request GET "$2" |grep message
+  curl -k -s -w "%{stderr}\n%{http_code}\n" --location --request GET "${fqdn}" |grep message
   sleep 5
   echo "[`date`] ..."
 done


### PR DESCRIPTION
* Add `--local` param to omit nameserver injection as we doing
  it in a demo pod when no edgeDNS provider configured
* Useful for live demo sessions, e.g. against EKS k8gb reference
  setup