### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -1,0 +1,55 @@
+name: Helm Publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: dave-mcconnell/helm-gh-pages-microservices@master
+        with:
+          access-token: ${{ secrets.CR_TOKEN }}
+          source-charts-folder: 'chart'
+          destination-repo: absaoss/k8gb
+          destination-branch: gh-pages
+      - name: Create single node k3s cluster
+        uses: AbsaOSS/k3d-action@v1.3.1
+        with:
+          cluster-name: "test-gslb1"
+          use-default-registry: false
+          args: >-
+            -p "80:80@agent[0]"
+            -p "443:443@agent[0]"
+            -p "5053:53/udp@agent[0]"
+            --agents 1
+            --no-lb
+            --network k3d-action-bridge-network
+            --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
+      - name: Smoke test helm installation
+        run: |
+          helm repo add k8gb https://absaoss.github.io/k8gb/
+          helm repo update
+          helm -n k8gb upgrade -i k8gb k8gb/k8gb --wait --create-namespace --version=$(make version)
+      - uses: heinrichreimer/github-changelog-generator-action@v2.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          project: k8gb
+      - name: Commit changelog
+        run: |
+          git config user.name 'Github Action'
+          git config user.email 'action@users.noreply.github.com'
+          git add CHANGELOG.md
+          git commit -m "Update Offline Changelog"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: "Update Offline Changelog"
+          branch: offline_changelog
+          delete-branch: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,49 +1,41 @@
-name: Helm Publish
+name: Release
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-20.04
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - uses: actions/checkout@v1
-      - name: Install golang linting tools
-        run: GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.32.0
-      - name: Operator image build and push
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get previous tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1.0.1
+        id: previoustag
+      - uses: heinrichreimer/github-changelog-generator-action@v2.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          project: k8gb
+          sinceTag: ${{ steps.previoustag.outputs.previous-tag }}
+          output: changes
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Login to Dockerhub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist --release-notes=changes
         env:
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_CLI_EXPERIMENTAL: "enabled"
-        run: |
-          export PATH=~/go/bin:$PATH
-          docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
-          make docker-build-multi
-          make docker-push-multi
-          make docker-manifest
-      - uses: dave-mcconnell/helm-gh-pages-microservices@master
-        with:
-          access-token: ${{ secrets.CR_TOKEN }}
-          source-charts-folder: 'chart'
-          destination-repo: absaoss/k8gb
-          destination-branch: gh-pages
-      - name: Create single node k3s cluster
-        uses: AbsaOSS/k3d-action@v1.3.1
-        with:
-          cluster-name: "test-gslb1"
-          use-default-registry: false
-          args: >-
-            -p "80:80@agent[0]"
-            -p "443:443@agent[0]"
-            -p "5053:53/udp@agent[0]"
-            --agents 1
-            --no-lb
-            --network k3d-action-bridge-network
-            --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
-      - name: Smoke test helm installation
-        run: |
-          helm repo add k8gb https://absaoss.github.io/k8gb/
-          helm repo update
-          helm -n k8gb upgrade -i k8gb k8gb/k8gb --wait --create-namespace --version=$(make version)
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ chart/k8gb/charts/*.tgz
 
 # Ignore testing kubeconfigs
 kubeconfig*
+
+# Ignore changes from github_changelog_generator action
+changes

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+before:
+  hooks:
+    - go mod download
+builds:
+  - env:
+      - CGO_ENABLED=0
+    id: k8gb
+    main: ./main.go
+    binary: bin/manager
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+dockers:
+- image_templates:
+  - "absaoss/k8gb:{{ .Tag }}-amd64"
+  use_buildx: false
+  dockerfile: Dockerfile-gr-amd64
+  build_flag_templates:
+  - "--platform=linux/amd64"
+- image_templates:
+  - "absaoss/k8gb:{{ .Tag }}-arm64"
+  use_buildx: false
+  goarch: arm64
+  dockerfile: Dockerfile-gr-arm64
+  build_flag_templates:
+  - "--platform=linux/arm64"
+docker_manifests:
+- name_template: absaoss/k8gb:{{ .Tag }}
+  image_templates:
+  - absaoss/k8gb:{{ .Tag }}-amd64
+  - absaoss/k8gb:{{ .Tag }}-arm64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+release:
+  draft: true

--- a/Dockerfile-gr-amd64
+++ b/Dockerfile-gr-amd64
@@ -1,0 +1,8 @@
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot-amd64
+WORKDIR /
+COPY manager .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/manager"]

--- a/Dockerfile-gr-arm64
+++ b/Dockerfile-gr-arm64
@@ -1,0 +1,8 @@
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot-arm64
+WORKDIR /
+COPY manager .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
    * Adds separate Dockerfile for each architecture to keep base image
      unchanged.
    * Brings github_changelog_generator into a release pipeline
    * Add .goreleaser.yaml with go build and amd64/arm64 images with docker
      common manifest
    * Introduce pipeline for tag event, where docker artifacts will be
      built.
    * Rename helm pipeline (release) into helm_publish

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>