### PR TITLE
Logger input Environment variables 

### DIFF
--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -27,8 +27,37 @@ import (
 
 	"github.com/AbsaOSS/k8gb/api/v1beta1"
 
+	"github.com/rs/zerolog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// LogFormat specifies how the logger prints values
+type LogFormat int8
+
+const (
+	// JSON prints messages as single json record
+	JSON LogFormat = 1 << iota
+	// Simple prints messages in human readable way
+	Simple
+	// Unrecognised, returned in situation when format is not recognised
+	Unrecognised
+)
+
+const (
+	json         = "json"
+	simple       = "simple"
+	unrecognised = "unrecognised"
+)
+
+func (f LogFormat) String() string {
+	switch f {
+	case JSON:
+		return json
+	case Simple:
+		return simple
+	}
+	return unrecognised
+}
 
 // EdgeDNSType specifies to which edge DNS is k8gb connecting
 type EdgeDNSType int
@@ -44,8 +73,17 @@ const (
 	DNSTypeNS1
 )
 
+// Log configuration
+type Log struct {
+	// Level [panic, fatal, error,warn,info,debug,trace], defines level of logger, default: info
+	Level zerolog.Level
+	// Format [simple,json] specifies how the logger prints values
+	Format LogFormat
+	// NoColor prints colored output if Format == simple
+	NoColor bool
+}
+
 // Infoblox configuration
-// TODO: consider to make this private after refactor
 type Infoblox struct {
 	// Host
 	Host string
@@ -99,6 +137,8 @@ type Config struct {
 	ns1Enabled bool
 	// CoreDNSExposed flag
 	CoreDNSExposed bool
+	// Log configuration
+	Log Log
 }
 
 // DependencyResolver resolves configuration for GSLB

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -87,6 +87,9 @@ var predefinedConfig = depresolver.Config{
 	Override: depresolver.Override{
 		FakeInfobloxEnabled: true,
 	},
+	Log: depresolver.Log{
+		Format: depresolver.Simple,
+	},
 }
 
 const coreDNSExtServiceName = "k8gb-coredns-lb"
@@ -1137,7 +1140,8 @@ func cleanup() {
 		depresolver.EdgeDNSZoneKey, depresolver.DNSZoneKey, depresolver.EdgeDNSServerKey, depresolver.K8gbNamespaceKey,
 		depresolver.Route53EnabledKey, depresolver.InfobloxGridHostKey, depresolver.InfobloxVersionKey, depresolver.InfobloxPortKey,
 		depresolver.InfobloxUsernameKey, depresolver.InfobloxPasswordKey, depresolver.InfobloxHTTPRequestTimeoutKey,
-		depresolver.InfobloxHTTPPoolConnectionsKey, depresolver.OverrideWithFakeDNSKey, depresolver.OverrideFakeInfobloxKey} {
+		depresolver.InfobloxHTTPPoolConnectionsKey, depresolver.OverrideWithFakeDNSKey, depresolver.OverrideFakeInfobloxKey,
+		depresolver.LogLevelKey, depresolver.LogFormatKey, depresolver.LogNoColorKey} {
 		if os.Unsetenv(s) != nil {
 			panic(fmt.Errorf("cleanup %s", s))
 		}
@@ -1162,4 +1166,7 @@ func configureEnvVar(config depresolver.Config) {
 	_ = os.Setenv(depresolver.InfobloxHTTPPoolConnectionsKey, strconv.Itoa(config.Infoblox.HTTPPoolConnections))
 	_ = os.Setenv(depresolver.OverrideWithFakeDNSKey, strconv.FormatBool(config.Override.FakeDNSEnabled))
 	_ = os.Setenv(depresolver.OverrideFakeInfobloxKey, strconv.FormatBool(config.Override.FakeInfobloxEnabled))
+	_ = os.Setenv(depresolver.LogLevelKey, config.Log.Level.String())
+	_ = os.Setenv(depresolver.LogFormatKey, config.Log.Format.String())
+	_ = os.Setenv(depresolver.LogNoColorKey, strconv.FormatBool(config.Log.NoColor))
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/miekg/dns v1.1.40
 	github.com/onsi/ginkgo v1.14.2 // indirect
 	github.com/prometheus/client_golang v1.9.0
+	github.com/rs/zerolog v1.20.0
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.20.4
 	k8s.io/apimachinery v0.20.4

--- a/go.sum
+++ b/go.sum
@@ -592,6 +592,11 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.18.0 h1:CbAm3kP2Tptby1i9sYy2MGRg0uxIN9cyDb59Ys7W8z8=
+github.com/rs/zerolog v1.18.0/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
+github.com/rs/zerolog v1.20.0 h1:38k9hgtUBdxFwE34yS8rTHmHBa4eN16E4DJlv177LNs=
+github.com/rs/zerolog v1.20.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -664,6 +669,7 @@ github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20200401174654-e694b7bb0875/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
@@ -899,6 +905,7 @@ golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190929041059-e7abfedfabcf/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/terratest/test/k8gb_lifecycle_test.go
+++ b/terratest/test/k8gb_lifecycle_test.go
@@ -108,7 +108,6 @@ func TestK8gbSpecKeepsStableAfterIngressUpdates(t *testing.T) {
 		assertGslbSpec(t, options, name, "spec.strategy.type", "failover")
 	}
 
-
 	kubeResourcePath, err := filepath.Abs("../examples/failover-spec.yaml")
 	ingressResourcePath, err := filepath.Abs("../examples/ingress-annotation-failover.yaml")
 	require.NoError(t, err)


### PR DESCRIPTION
Code implements depresolver part - logger inputs
Input variables defines how will looger act.
 - propagation new config variables: `LOG_FORMAT `,`LOG_LEVEL`, `NO_COLOR`
 - All covered by unit-tests
 - `LOG_LEVEL` accepts zerolog values `panic`, `fatal`, `error`,`warn`,`info`,`debug`,`trace` and `''`.
  Values could be  **case insensitive**, so `PANIC`, `Trace` are still valid values.  If we don't set variable,
  then depresolver use `info` as default value. If `LOG_LEVEL` is invalid, depresolver returns an error
  so `main` can exit.
 - `LOG_FORMAT` saying how are log records printed. It accepts case insensitive values `['','json','simple']`.
  Default value `json`. In case of invalid value returns an error so `main` can exit.
 - `NO_COLOR` is bool value indicating colored input. Variable is useful only if `LOG_FORMAT == simple`.
  default value is `true`.

Related to #331

