### PR TITLE
Remove `udp-services` ConfigMap from k8gb helm chart templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ Simply run
 make deploy-full-local-setup
 ```
 
-It will deploy two local [k3s](https://k3s.io/) clusters via [k3d](https://k3d.io/) with
-k8gb, test application and two sample Gslb resources on top.
+It will deploy two local [k3s](https://k3s.io/) clusters via [k3d](https://k3d.io/), [expose associated CoreDNS service for UDP DNS traffic](./docs/exposing_dns.md)), and install k8gb with test applications and two sample Gslb resources on top.
 
 This setup is adapted for local scenario and works without external DNS provider dependency.
 

--- a/chart/k8gb/templates/ingress/udp-services.yaml
+++ b/chart/k8gb/templates/ingress/udp-services.yaml
@@ -1,9 +1,0 @@
-{{ if .Values.externaldns.expose53onWorkers }}
-apiVersion: v1
-data:
-  "53": k8gb/k8gb-coredns:53
-kind: ConfigMap
-metadata:
-  name: udp-services
-  namespace: {{ .Values.k8gb.ingressNamespace }}
-{{ end }}

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -7,7 +7,6 @@ global:
 
 k8gb:
   imageRepo: absaoss/k8gb # image tag is defined in Chart.AppVersion, see Chart.yaml
-  ingressNamespace: "k8gb"
   dnsZone: "cloud.example.com" # dnsZone controlled by gslb
   edgeDNSZone: "example.com" # main zone which would contain gslb zone to delegate
   edgeDNSServer: "1.1.1.1" # use this DNS server as a main resolver to enable cross k8gb DNS based communication
@@ -24,7 +23,6 @@ k8gb:
 externaldns:
   image: k8s.gcr.io/external-dns/external-dns:v0.7.6
   interval: "20s"
-  expose53onWorkers: true # open 53/udp on workers nodes with nginx controller
   securityContext:
     fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
     runAsUser: 1000

--- a/docs/deploy_infoblox.md
+++ b/docs/deploy_infoblox.md
@@ -15,16 +15,15 @@ cp chart/k8gb/values.yaml ~/k8gb/eu-cluster.yaml
 ```
 
 * Modify the example configuration. Important parameters described below:
-  * `ingressNamespace` - modify it to the namespace where the Nginx ingress controller is installed. In case of Rancher provisioned cluster it is `ingress-nginx`. If you do not have Nginx ingress preinstalled you can use `make deploy-local-ingress` to install and leave this value as `k8gb`
   * `dnsZone` - this zone will be delegated to the `edgeDNS` in your environment. E.g. `yourzone.edgedns.com`
   * `edgeDNSZone` - this zone will be automatically configured by k8gb to delegate to `dnsZone` and will make k8gb controlled nodes act as authoritative server for this zone. E.g. `edgedns.com`
   * `edgeDNSServer` stable DNS server in your environment that is controlled by edgeDNS provider e.g. Infoblox so k8gb instances will be able to talk to each other through automatically created DNS names
   * `clusterGeoTag` to geographically tag your cluster. We are operating `eu` cluster in this example
   * `extGslbClustersGeoTags` contains Geo tag of the cluster(s) to talk with when k8gb is deployed to multiple clusters. Imagine your second cluster is `us` so we tag it accordingly
-  * `infoblox.enabled: true` to enable automated zone delegation configuration at edgeDNS provider. You don't need it for totally local test and can optionally skip it. Meanwhile in this how-to we will cover a fully operational end-to-end scenario. Support of other provider like Route53 is on our [Roadmap](https://github.com/AbsaOSS/k8gb/issues)
+  * `infoblox.enabled: true` to enable automated zone delegation configuration at edgeDNS provider. You don't need it for local testing and can optionally be skipped. Meanwhile, in this section we will cover a fully operational end-to-end scenario.
 The other parameters do not need to be modified unless you want to do something special. E.g. to use images from private registry
 
-* Export Infoblox related information in the shell. Instead of $ variables use the actual versions
+  * Export Infoblox related information in the shell.
 ```sh
 export WAPI_USERNAME=<WAPI_USERNAME>
 export WAPI_PASSWORD=<WAPI_PASSWORD>
@@ -36,6 +35,9 @@ kubectl create ns k8gb
 make infoblox-secret
 ```
 
+* Expose associated k8gb CoreDNS service for DNS traffic on worker nodes.
+  > Check [this document](./exposing_dns.md) for detailed information.
+
 * Let's deploy k8gb to the first cluster. Most of the helper commands are abstracted by GNU `make`. If you want to look under the hood please check the `Makefile`. In general, standard Kubernetes/Helm commands are used. Point deployment mechanism to your custom `values.yaml`
 ```sh
 make deploy-gslb-operator VALUES_YAML=~/k8gb/eu-cluster.yaml
@@ -45,7 +47,6 @@ make deploy-gslb-operator VALUES_YAML=~/k8gb/eu-cluster.yaml
 ```sh
  kubectl -n k8gb get pod
 NAME                                                       READY   STATUS     RESTARTS   AGE
-external-dns-79d5ccd7fc-4bj74                              1/1     Running    0          39s
 k8gb-76cc56b55-t779s                                       1/1     Running    0          39s
 k8gb-coredns-799984c646-qz88m                              1/1     Running    0          41s
 ```

--- a/docs/examples/ns1/k8gb-cluster-ns1-eu-west-1.yaml
+++ b/docs/examples/ns1/k8gb-cluster-ns1-eu-west-1.yaml
@@ -6,8 +6,5 @@ k8gb:
   extGslbClustersGeoTags: "us-east-1" # comma-separated list of external gslb geo tags to pair with
   exposeCoreDNS: true # Create Service type LoadBalancer to expose CoreDNS
 
-externaldns:
-  expose53onWorkers: false # open 53/udp on workers nodes with nginx controller
-
 ns1:
   enabled: true

--- a/docs/examples/ns1/k8gb-cluster-ns1-us-east-1.yaml
+++ b/docs/examples/ns1/k8gb-cluster-ns1-us-east-1.yaml
@@ -6,8 +6,5 @@ k8gb:
   extGslbClustersGeoTags: "eu-west-1" # comma-separated list of external gslb geo tags to pair with
   exposeCoreDNS: true # Create Service type LoadBalancer to expose CoreDNS
 
-externaldns:
-  expose53onWorkers: false # open 53/udp on workers nodes with nginx controller
-
 ns1:
   enabled: true

--- a/docs/examples/route53/k8gb/k8gb-cluster-eu-west-1.yaml
+++ b/docs/examples/route53/k8gb/k8gb-cluster-eu-west-1.yaml
@@ -6,9 +6,6 @@ k8gb:
   extGslbClustersGeoTags: "us-east-1" # comma-separated list of external gslb geo tags to pair with
   exposeCoreDNS: true # Create Service type LoadBalancer to expose CoreDNS
 
-externaldns:
-  expose53onWorkers: false # open 53/udp on workers nodes with nginx controller
-
 route53:
   enabled: true
   hostedZoneID: Z<zone-id>

--- a/docs/examples/route53/k8gb/k8gb-cluster-us-east-1.yaml
+++ b/docs/examples/route53/k8gb/k8gb-cluster-us-east-1.yaml
@@ -6,9 +6,6 @@ k8gb:
   extGslbClustersGeoTags: "eu-west-1" # comma-separated list of external gslb geo tags to pair with
   exposeCoreDNS: true # Create Service type LoadBalancer to expose CoreDNS
 
-externaldns:
-  expose53onWorkers: false # open 53/udp on workers nodes with nginx controller
-
 route53:
   enabled: true
   hostedZoneID: Z<zone-id>

--- a/docs/exposing_dns.md
+++ b/docs/exposing_dns.md
@@ -1,0 +1,76 @@
+# Exposing DNS UDP traffic for k8gb
+
+In order for k8gb to function properly, associated CoreDNS service deployed with k8gb needs be exposed for external DNS UDP traffic on cluster worker nodes.
+
+Actual ways to achieve this depend on many factors, such as underlying infrastructure (cloud, on-prem, managed vs bare-metal setup), means to expose CoreDNS service (ClusterIP, LoadBalancer),
+type of load balancer or ingress controller used etc.
+This topic is outside the project's scope, as often the related configuration is shared by cluster services, requires additional permissions, and as result can't be owned by k8gb controller deployment.
+However, we can describe a few examples using common Kubernetes configurations, which have been thoroughly tested in local and production environments.
+
+## Ingress Controller with UDP support (NGINX)
+
+> *Check [NGINX Ingress controller official documentation](https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/) for additional information*
+
+In general, an Ingress resource doesn't support TCP or UDP services. In order to let NGINX Ingress controller know that we want to expose UDP port for k8gb CoreDNS service (`k8gb-coredns`), we need to create or patch `udp-services` ConfigMap in a namespace where NGINX ingress controller is installed (`ingress-nginx` by default).
+Its `data` section would contain UDP 53 port mapping for CoreDNS service deployed with k8gb chart release.
+> *Associated CoreDNS service can be found in the same namespace where k8gb chart release is deployed. Service name is prefixed with chart release name.*
+
+Example `udp-services` ConfigMap manifest:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: udp-services
+  namespace: ingress-nginx
+data:
+  53: "k8gb/k8gb-coredns:53"  # <== "<K8GB_DEPLOYMENT_NAMESPACE>/<K8GB_CHART_RELEASE>-coredns"
+```
+
+It can be also created or patched by running `kubectl` one-liner:
+
+```sh
+# Patch the existing `udp-services` ConfigMap in NGINX Ingress controller namespace:
+
+kubectl patch -n ingress-nginx -p '{"data":{"53":"k8gb/k8gb-coredns:53"}}' --type=merge cm/udp-services
+
+# Or create `udp-services` ConfigMap if it doesn't exist, e.g.:
+
+kubectl create -n ingress-nginx cm udp-services --from-literal="53"="k8gb/k8gb-coredns:53"
+```
+
+[Local project setup](./local.md) does this patching automatically.
+
+## External load balancer
+
+CoreDNS can be also exposed for DNS UDP traffic via external load balancer,
+if underlying infrastructure supports that.<br>
+[AWS EKS](https://aws.amazon.com/eks) with [NLB](https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html) and [k3d](https://www.k3d.io) with [ServiceLB](https://rancher.com/docs/k3s/latest/en/networking/#service-load-balancer) are good examples of such an infrastructure proven to work for k8gb deployments.<br>
+We're using this approach in our [AWS+Route53](deploy_route53.md) reference setup, with [k8gb helm chart](https://artifacthub.io/packages/helm/k8gb/k8gb) providing out of the box support for external load balancer scenario. CoreDNS service is exposed by setting `k8gb.exposeCoreDNS` helm chart value to `true`:
+```yaml
+# k8gb helm chart values.yaml example:
+
+k8gb:
+  ...
+  exposeCoreDNS: true # <== expose UDP DNS traffic via external load balancer
+```
+
+In general, resulting `Service` resource configuration for k8gb CoreDNS looks like:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb # <== tell AWS to use NLB load balancer
+  name: k8gb-coredns-lb
+  namespace: k8gb
+spec:
+  ports:
+  - name: udp-53 # specify DNS UDP port (53)
+    port: 53
+    protocol: UDP
+  selector:
+    app.kubernetes.io/instance: k8gb
+    app.kubernetes.io/name: coredns
+  type: LoadBalancer # <== set service type to LoadBalancer
+```

--- a/docs/local.md
+++ b/docs/local.md
@@ -1,3 +1,4 @@
+<!-- omit in toc -->
 # Local playground for testing and development
 
 - [Environment prerequisites](#environment-prerequisites)
@@ -5,44 +6,47 @@
 - [Verify installation](#verify-installation)
 - [Run integration tests](#run-integration-tests)
 - [Cleaning](#cleaning)
+- [Sample demo](#sample-demo)
+  - [Round Robin](#round-robin)
+  - [Failover](#failover)
 
-#### Environment prerequisites
+## Environment prerequisites
 
- - [install **GO 1.14**](https://golang.org/dl/)
+- [Install **go 1.15**](https://golang.org/dl/)
 
- - [install **GIT**](https://git-scm.com/downloads)
+- [Install **git**](https://git-scm.com/downloads)
 
- - install **gnu-sed** if you don't have it
-    - If you are on a Mac, install sed by Homebrew
+- Install **gnu-sed** if you don't have it. If you are on a Mac, install sed by Homebrew
     ```shell script
     brew install gnu-sed
     ```
 
- - [install **Docker**](https://docs.docker.com/get-docker/)
-    - ensure you are able to push/pull from your docker registry
-    - to run multiple clusters reserve 8GB of memory
+- [Install **Docker**](https://docs.docker.com/get-docker/)
+  > Ensure you are able to push/pull from your docker registry
 
-      ![](/docs/images/docker_settings.png)
+  > To run multiple clusters, reserve 8GB of memory*
+    ![](/docs/images/docker_settings.png)
       <div>
-        <sup>above screenshot is for <strong>Docker for Mac</strong> and that options for other Docker distributions may vary</sup>
+        <sup><i>* above screenshot is provided for <strong>Docker for Mac</strong>, options for other Docker distributions may vary
+        </i></sup>
       </div>
 
- - [install **Kubectl**](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to operate clusters
+ - [install **kubectl**](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to operate clusters
 
- - [install **Helm3**](https://helm.sh/docs/intro/install/) to get charts
+ - [install **helm3**](https://helm.sh/docs/intro/install/) to get charts
 
- - [install **k3d**](https://k3d.io/) as tool for running local [k3s](https://k3s.io/) clusters
-    - follow https://k3d.io/#installation
+ - [install **k3d**](https://k3d.io/) as tool for running local [k3s](https://k3s.io/) clusters.<br>
+   > Follow https://k3d.io/#installation
 
 
-#### Running project locally
+## Running project locally
 
 To spin-up a local environment using two k3s clusters and deploy a test application to both clusters, execute the command below:
 ```shell script
 make deploy-full-local-setup
 ```
 
-#### Verify installation
+## Verify installation
 
 If local setup runs well, check if clusters are correctly installed
 
@@ -77,7 +81,7 @@ Run following command and check if you get two json responses.
 curl localhost:80 -H "Host:roundrobin.cloud.example.com" && curl localhost:81 -H "Host:roundrobin.cloud.example.com"
 ```
 
-#### Run integration tests
+## Run integration tests
 
 There is wide range of scenarios which **GSLB** provides and all of them are covered within [tests](https://github.com/AbsaOSS/k8gb/tree/master/terratest).
 To check whether everything is running properly execute [terratest](https://terratest.gruntwork.io/) :
@@ -86,7 +90,7 @@ To check whether everything is running properly execute [terratest](https://terr
 make terratest
 ```
 
-#### Cleaning
+## Cleaning
 
 Clean up your local development clusters with
 ```shell script


### PR DESCRIPTION
- Removed NGINX Ingress Controller `udp-services` ConfigMap from k8gb chart templates.
- Updated k8gb documentation and example values files in order to reflect removal.
- Created documentation explaining DNS traffic configuration
- Amended general and local setup documentation

This PR closes #352 and #323