### PR TITLE
Reduce load on test setup

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -23,7 +23,7 @@ jobs:
             -p "80:80@agent[0]"
             -p "443:443@agent[0]"
             -p "5053:53/udp@agent[0]"
-            --agents 3
+            --agents 1
             --no-lb
             --network k3d-action-bridge-network
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
@@ -38,7 +38,7 @@ jobs:
             -p "444:443@agent[0]"
             -p "5054:53/udp@agent[0]"
             --network k3d-action-bridge-network
-            --agents 3
+            --agents 1
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ help: ## Show this help
 define create-local-cluster
 	@echo "\n$(YELLOW)Deploy local cluster $(CYAN)$1 $(NC)"
 	k3d cluster create $1 $2 \
-	--agents 3 --no-lb --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server" --network $(CLUSTER_GSLB_NETWORK)
+	--agents 1 --no-lb --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server" --network $(CLUSTER_GSLB_NETWORK)
 endef
 
 define deploy-local-cluster

--- a/deploy/test-apps/podinfo/podinfo-values.yaml
+++ b/deploy/test-apps/podinfo/podinfo-values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 2
+replicaCount: 1
 
 image:
   repository: stefanprodan/podinfo

--- a/terratest/test/k8gb_split_failover_test.go
+++ b/terratest/test/k8gb_split_failover_test.go
@@ -138,7 +138,7 @@ func TestK8gbSplitFailoverExample(t *testing.T) {
 
 	t.Run("serviceHealth becomes Healthy after scaling up", func(t *testing.T) {
 
-		k8s.RunKubectl(t, optionsContext1, "scale", "deploy", "frontend-podinfo", "--replicas=2")
+		k8s.RunKubectl(t, optionsContext1, "scale", "deploy", "frontend-podinfo", "--replicas=1")
 
 		assertGslbStatus(t, optionsContext1, gslbName, "terratest-failover-split.cloud.example.com:Healthy")
 	})


### PR DESCRIPTION
This commit reduces number of k3d workers from 3 to 1 and number of
podinfo replicas from 2 to 1. That should increase requirements for test
setup and speed of tests.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>