### PR TITLE
Remove deploy-gslb-operator-14 make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,13 +127,6 @@ deploy-gslb-operator: ## Deploy k8gb operator
 	cd chart/k8gb && helm dependency update
 	helm -n k8gb upgrade -i k8gb chart/k8gb -f $(VALUES_YAML) $(HELM_ARGS)
 
-# workaround until https://github.com/crossplaneio/crossplane/issues/1170 solved
-.PHONY: deploy-gslb-operator-14
-deploy-gslb-operator-14:
-	kubectl apply -f deploy/namespace.yaml
-	cd chart/k8gb && helm dependency update
-	helm -n k8gb template k8gb chart/k8gb -f $(VALUES_YAML) | kubectl -n k8gb --validate=false apply -f -
-
 .PHONY: deploy-gslb-cr
 deploy-gslb-cr: ## Apply Gslb Custom Resources
 	kubectl apply -f deploy/crds/test-namespace.yaml


### PR DESCRIPTION
Motivation:
- k8s v1.14 is long time EOL.
- https://github.com/crossplaneio/crossplane/issues/1170 is solved,
helm supports `--disable-openapi-validation` flag since version 3.1,
if user still needs to run deployment on v1.14 cluster without pre-rendering
to k8s manifests.