### PR TITLE
Update DNSEndpoint CRD

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -17,5 +17,4 @@ jobs:
         id: kube-lint-repo
         uses: stackrox/kube-linter-action@v1.0.0
         with:
-          config: .kube-linter.yaml
           directory: chart

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,3 +1,0 @@
-checks:
-  exclude:
-  - "no-extensions-v1beta"

--- a/chart/k8gb/templates/dns-endpoint-crd-manifest.yaml
+++ b/chart/k8gb/templates/dns-endpoint-crd-manifest.yaml
@@ -1,66 +1,93 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-sigs/external-dns/pull/2007"
   creationTimestamp: null
-  labels:
-    api: externaldns
-    kubebuilder.k8s.io: 1.0.0
   name: dnsendpoints.externaldns.k8s.io
 spec:
   group: externaldns.k8s.io
   names:
     kind: DNSEndpoint
+    listKind: DNSEndpointList
     plural: dnsendpoints
+    singular: dnsendpoint
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            endpoints:
-              items:
-                properties:
-                  dnsName:
-                    type: string
-                  labels:
-                    type: object
-                  providerSpecific:
-                    items:
-                      properties:
-                        name: 
-                          type: string
-                        value:
-                          type: string
-                      type: object
-                    type: array
-                  recordTTL:
-                    format: int64
-                    type: integer
-                  recordType:
-                    type: string
-                  targets:
-                    items:
-                      type: string
-                    type: array
-                type: object
-              type: array
-          type: object
-        status:
-          properties:
-            observedGeneration:
-              format: int64
-              type: integer
-          type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSEndpointSpec defines the desired state of DNSEndpoint
+            properties:
+              endpoints:
+                items:
+                  description: Endpoint is a high-level way of a connection between a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, SRV, TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with the same name and type (e.g. Route53 records with routing policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            description: DNSEndpointStatus defines the observed state of DNSEndpoint
+            properties:
+              observedGeneration:
+                description: The generation observed by the external-dns controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
Sync DNSEndpoint CRD from upstream where it was updated to
apiextentions.k8s.io/v1

https://github.com/kubernetes-sigs/external-dns/pull/2001

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>