### PR TITLE
Drop linter from terratest action

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -42,7 +42,6 @@ jobs:
 
       - name: K8GB deployment
         run: |
-          GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.32.0
           make deploy-to-AbsaOSS-k3d-action
 
       - name: Terratest


### PR DESCRIPTION
It is not really used during that step

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>