### PR TITLE
Golic CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Golang lint and test
+name: Golang lint, golic and test
 on:
   push:
     paths-ignore:
@@ -17,5 +17,9 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.32
+      - name: golic
+        run: |
+          go install github.com/AbsaOSS/golic@v0.4.4
+          golic inject -c "2021 Absa Group Limited" --dry -x
       - name: go test
         run: go test ./...

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ ifeq (, $(shell which golic))
 	GOLIC_TMP_DIR=$$(mktemp -d) ;\
 	cd $$GOLIC_TMP_DIR ;\
 	go mod init tmp ;\
-	go get github.com/AbsaOSS/golic@v0.3.1 ;\
+	go get github.com/AbsaOSS/golic@v0.4.4 ;\
 	rm -rf $$GOLIC_TMP_DIR ;\
 	}
 GOLIC=$(GOBIN)/golic
@@ -292,7 +292,7 @@ start-test-app:
 
 # run tests
 .PHONY: test
-test: license lint
+test: lint
 	$(call generate)
 	$(call manifest)
 	go test ./... -coverprofile cover.out


### PR DESCRIPTION
- Makefile: remove license from test target
- CI, install and run golic v0.4.4
- license target can modify files, while build step is `--dry -x`
 
*picture below shows what happens if some file doesn't have expected license*
![Screenshot 2021-03-17 at 18 16 20](https://user-images.githubusercontent.com/7195836/111509303-e12cb580-874c-11eb-8e97-15921a0bbdd6.png)