### PR TITLE
Workaround goreleaser not pushing docker images.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      # Hack around until https://github.com/goreleaser/goreleaser/pull/2119 is fixed
+      - name: Operator image build and push
+        run: |
+          export PATH=~/go/bin:$PATH
+          make docker-build-multi
+          make docker-push-multi
+          make docker-manifest
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
goreleaser on release draft doesn't push docker images to the registry,
hence docker manifest build fails. Build and push images in advance
until https://github.com/goreleaser/goreleaser/pull/2119 is merged

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>