### PR TITLE
bump golic version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           version: v1.32
       - name: golic
         run: |
-          go install github.com/AbsaOSS/golic@v0.4.4
+          go install github.com/AbsaOSS/golic@v0.4.7
           golic inject -c "2021 Absa Group Limited" --dry -x
       - name: go test
         run: go test ./...


### PR DESCRIPTION
The problem is , golic uses online master configuration, which is shared between all golic versions. Change in v0.4.7 affects v0.4.4

The problem will be resolved when master config will be attached to golic binary as an embedded resource . 