### PR TITLE
Rollback external-dns to get NS record creation back

### DIFF
--- a/chart/k8gb/templates/external-dns/external-dns-route53.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns-route53.yaml
@@ -27,7 +27,6 @@ spec:
         - --txt-owner-id=k8gb-{{ .Values.route53.hostedZoneID }}-{{ .Values.k8gb.clusterGeoTag }}
         - --policy=sync # enable full synchronization including record removal
         - --log-level=debug # debug only
-        - --managed-record-types=A,CNAME,NS
         resources:
           requests:
             memory: "32Mi"

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -24,7 +24,7 @@ k8gb:
   exposeCoreDNS: false # Create Service type LoadBalancer to expose CoreDNS
 
 externaldns:
-  image: k8s.gcr.io/external-dns/external-dns:v0.7.6
+  image: k8s.gcr.io/external-dns/external-dns:v0.7.5
   interval: "20s"
   securityContext:
     fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files


### PR DESCRIPTION
* external-dns `v0.7.6` included https://github.com/kubernetes-sigs/external-dns/pull/1915/files
* Even with `--managed-record-types=A,CNAME,NS` it silently skips NS
  record type creation
* `test.k8gb.io` NS record was staying orphaned and undeleted in reference setup
  configuration making an illusion that everything is properly working
  with route53 based zone delegation
* Switch back to reliable `v0.7.5` where NS record support was introduced
  at https://github.com/kubernetes-sigs/external-dns/pull/1813

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>