### PR TITLE
Enable relative makrdown links on k8gb.io gh pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,8 @@ theme: jekyll-theme-cayman
 markdown: GFM
 include: CONTRIBUTING.md
 google_analytics: G-HMZ7QVHJH0
+plugins:
+  - jekyll-relative-links
+relative_links:
+  enabled: true
+  collections: true


### PR DESCRIPTION
Incorporate https://github.com/benbalter/jekyll-relative-links

It will enable easier documentation cross referencing as in
https://github.com/benbalter/jekyll-relative-links#processing-collections

Also we currently have a bug in the
docs(https://www.k8gb.io/docs/deploy_ns1.html)
where `.md` is not automatically converted to `.html` link.

This plugin should also solve this issue when we convert the links
to relatives inside non top-level parts documentation.

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>