### PR TITLE
Fix github_changelog_generator defaults

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -40,6 +40,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           project: k8gb
+          pullRequests: true
+          author: true
+          issues: true
+          issuesWoLabels: true
+          prWoLabels: true
+          compareLink: true
+          filterByMilestone: true
+          unreleased: true
       - name: Commit changelog
         run: |
           git config user.name 'Github Action'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,16 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           project: k8gb
-          pullRequests: true
           sinceTag: ${{ steps.get_tag.outputs.previous_tag }}
           output: changes
+          pullRequests: true
+          author: true
+          issues: true
+          issuesWoLabels: true
+          prWoLabels: true
+          compareLink: true
+          filterByMilestone: true
+          unreleased: true
       - name: Set up Go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Due to bug https://github.com/heinrichreimer/action-github-changelog-generator/issues/23
we have to set booleans explicitly.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>