### PR TITLE
Improve logging for missing environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@ LOG_FORMAT ?= simple
 LOG_LEVEL ?= debug
 CONTROLLER_GEN_VERSION  ?= v0.4.1
 GOLIC_VERSION  ?= v0.4.7
+POD_NAMESPACE ?= k8gb
+CLUSTER_GEO_TAG ?= eu
+EXT_GSLB_CLUSTERS_GEO_TAGS ?= us
+EDGE_DNS_SERVER ?= 1.1.1.1
+EDGE_DNS_ZONE ?= example.com
+DNS_ZONE ?= cloud.example.com
 
 ifndef NO_COLOR
 YELLOW=\033[0;33m
@@ -247,7 +253,15 @@ reset:	destroy-full-local-setup deploy-full-local-setup
 run: lint
 	$(call generate)
 	$(call manifest)
-	LOG_FORMAT=$(LOG_FORMAT) go run ./main.go
+	LOG_FORMAT=$(LOG_FORMAT) \
+	LOG_LEVEL=$(LOG_LEVEL) \
+	POD_NAMESPACE=$(POD_NAMESPACE) \
+	CLUSTER_GEO_TAG=$(CLUSTER_GEO_TAG) \
+	EXT_GSLB_CLUSTERS_GEO_TAGS=$(EXT_GSLB_CLUSTERS_GEO_TAGS) \
+	EDGE_DNS_SERVER=$(EDGE_DNS_SERVER) \
+	EDGE_DNS_ZONE=$(EDGE_DNS_ZONE) \
+	DNS_ZONE=$(DNS_ZONE) \
+	go run ./main.go
 
 .PHONY: stop-test-app
 stop-test-app:

--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -87,74 +87,75 @@ func (dr *DependencyResolver) ResolveOperatorConfig() (*Config, error) {
 
 func (dr *DependencyResolver) validateConfig(config *Config) (err error) {
 	if config.Log.Level == zerolog.NoLevel {
-		return fmt.Errorf("invalid %s, allowed values ['','%s','%s','%s','%s','%s','%s','%s']", LogLevelKey,
+		return fmt.Errorf("invalid '%s', allowed values ['','%s','%s','%s','%s','%s','%s','%s']", LogLevelKey,
 			zerolog.TraceLevel, zerolog.DebugLevel, zerolog.InfoLevel, zerolog.WarnLevel, zerolog.FatalLevel,
 			zerolog.DebugLevel, zerolog.PanicLevel)
 	}
 	if config.Log.Format == NoFormat {
-		return fmt.Errorf("invalid %s, allowed values ['','%s','%s']", LogFormatKey, JSONFormat, SimpleFormat)
+		return fmt.Errorf("invalid '%s', allowed values ['','%s','%s']", LogFormatKey, JSONFormat, SimpleFormat)
 	}
-	err = field("k8gbNamespace", config.K8gbNamespace).isNotEmpty().matchRegexp(k8sNamespaceRegex).err
+	err = field(K8gbNamespaceKey, config.K8gbNamespace).isNotEmpty().matchRegexp(k8sNamespaceRegex).err
 	if err != nil {
 		return err
 	}
-	err = field("reconcileRequeueSeconds", config.ReconcileRequeueSeconds).isHigherThanZero().err
+	err = field(ReconcileRequeueSecondsKey, config.ReconcileRequeueSeconds).isHigherThanZero().err
 	if err != nil {
 		return err
 	}
-	err = field("clusterGeoTag", config.ClusterGeoTag).isNotEmpty().matchRegexp(geoTagRegex).err
+	err = field(ClusterGeoTagKey, config.ClusterGeoTag).isNotEmpty().matchRegexp(geoTagRegex).err
 	if err != nil {
 		return err
 	}
-	err = field("extClusterGeoTags", config.ExtClustersGeoTags).hasItems().hasUniqueItems().err
+	err = field(ExtClustersGeoTagsKey, config.ExtClustersGeoTags).hasItems().hasUniqueItems().err
 	if err != nil {
 		return err
 	}
 	for i, geoTag := range config.ExtClustersGeoTags {
-		err = field(fmt.Sprintf("extClustersGeoTags[%v]", i), geoTag).isNotEmpty().matchRegexp(geoTagRegex).isNotEqualTo(config.ClusterGeoTag).err
+		err = field(fmt.Sprintf("%s[%v]", ExtClustersGeoTagsKey, i), geoTag).
+			isNotEmpty().matchRegexp(geoTagRegex).isNotEqualTo(config.ClusterGeoTag).err
 		if err != nil {
 			return err
 		}
 	}
-	err = field("edgeDNSServer", config.EdgeDNSServer).isNotEmpty().matchRegexps(hostNameRegex, ipAddressRegex).err
+	err = field(EdgeDNSServerKey, config.EdgeDNSServer).isNotEmpty().matchRegexps(hostNameRegex, ipAddressRegex).err
 	if err != nil {
 		return err
 	}
-	err = field("edgeDNSZone", config.EdgeDNSZone).isNotEmpty().matchRegexp(hostNameRegex).err
+	err = field(EdgeDNSZoneKey, config.EdgeDNSZone).isNotEmpty().matchRegexp(hostNameRegex).err
 	if err != nil {
 		return err
 	}
-	err = field("DNSZone", config.DNSZone).isNotEmpty().matchRegexp(hostNameRegex).err
+	err = field(DNSZoneKey, config.DNSZone).isNotEmpty().matchRegexp(hostNameRegex).err
 	if err != nil {
 		return err
 	}
 	// do full Infoblox validation only in case that Host exists
 	if isNotEmpty(config.Infoblox.Host) {
-		err = field("InfobloxGridHost", config.Infoblox.Host).matchRegexps(hostNameRegex, ipAddressRegex).err
+		err = field(InfobloxGridHostKey, config.Infoblox.Host).matchRegexps(hostNameRegex, ipAddressRegex).err
 		if err != nil {
 			return err
 		}
-		err = field("InfobloxVersion", config.Infoblox.Version).isNotEmpty().matchRegexp(versionNumberRegex).err
+		err = field(InfobloxVersionKey, config.Infoblox.Version).isNotEmpty().matchRegexp(versionNumberRegex).err
 		if err != nil {
 			return err
 		}
-		err = field("InfobloxPort", config.Infoblox.Port).isHigherThanZero().isLessOrEqualTo(65535).err
+		err = field(InfobloxPortKey, config.Infoblox.Port).isHigherThanZero().isLessOrEqualTo(65535).err
 		if err != nil {
 			return err
 		}
-		err = field("InfobloxUsername", config.Infoblox.Username).isNotEmpty().err
+		err = field(InfobloxUsernameKey, config.Infoblox.Username).isNotEmpty().err
 		if err != nil {
 			return err
 		}
-		err = field("InfobloxPassword", config.Infoblox.Password).isNotEmpty().err
+		err = field(InfobloxPasswordKey, config.Infoblox.Password).isNotEmpty().err
 		if err != nil {
 			return err
 		}
-		err = field("InfobloxHTTPPoolConnections", config.Infoblox.HTTPPoolConnections).isHigherOrEqualToZero().err
+		err = field(InfobloxHTTPPoolConnectionsKey, config.Infoblox.HTTPPoolConnections).isHigherOrEqualToZero().err
 		if err != nil {
 			return err
 		}
-		err = field("InfobloxHTTPRequestTimeout", config.Infoblox.HTTPRequestTimeout).isHigherThanZero().err
+		err = field(InfobloxHTTPRequestTimeoutKey, config.Infoblox.HTTPRequestTimeout).isHigherThanZero().err
 		if err != nil {
 			return err
 		}

--- a/controllers/depresolver/depresolver_validator.go
+++ b/controllers/depresolver/depresolver_validator.go
@@ -66,7 +66,7 @@ func field(name string, value interface{}) *validator {
 		validator.strArr = v
 	default:
 		// float32, float64, bool, interface{}, maps, slices, Custom Types
-		validator.err = fmt.Errorf("can't parse %v of type %T as int or string", v, v)
+		validator.err = fmt.Errorf("can't parse '%v' of type '%T' as int or string", v, v)
 	}
 	return validator
 }
@@ -76,7 +76,7 @@ func (v *validator) isNotEmpty() *validator {
 		return v
 	}
 	if v.strValue == "" {
-		v.err = fmt.Errorf("%s is empty", v.name)
+		v.err = fmt.Errorf("'%s' is empty", v.name)
 	}
 	return v
 }
@@ -90,7 +90,7 @@ func (v *validator) matchRegexp(regex string) *validator {
 	}
 	r, _ := regexp.Compile(regex)
 	if !r.Match([]byte(v.strValue)) {
-		v.err = fmt.Errorf(`"%s" does not match given criteria. see: https://www.regextester.com (%s)`, v.strValue, regex)
+		v.err = fmt.Errorf(`'%s' does not match given criteria. see: https://www.regextester.com (%s)`, v.strValue, regex)
 	}
 	return v
 }
@@ -114,7 +114,7 @@ func (v *validator) isHigherThanZero() *validator {
 		return v
 	}
 	if v.intValue <= 0 {
-		v.err = fmt.Errorf(`"%s" is less or equal to zero`, v.name)
+		v.err = fmt.Errorf(`'%s' is less or equal to zero`, v.name)
 	}
 	return v
 }
@@ -124,7 +124,7 @@ func (v *validator) isHigherOrEqualToZero() *validator {
 		return v
 	}
 	if v.intValue < 0 {
-		v.err = fmt.Errorf(`"%s" is less than zero`, v.name)
+		v.err = fmt.Errorf(`'%s' is less than zero`, v.name)
 	}
 	return v
 }
@@ -134,7 +134,7 @@ func (v *validator) isLessOrEqualTo(num int) *validator {
 		return v
 	}
 	if v.intValue > num {
-		v.err = fmt.Errorf(`"%s" is higher than %v`, v.name, num)
+		v.err = fmt.Errorf(`'%s' is higher than '%v'`, v.name, num)
 	}
 	return v
 }
@@ -144,7 +144,7 @@ func (v *validator) isNotEqualTo(value string) *validator {
 		return v
 	}
 	if v.strValue == value {
-		v.err = fmt.Errorf(`"%s" can't be equal to "%s"`, v.name, value)
+		v.err = fmt.Errorf(`'%s' can't be equal to '%s'`, v.name, value)
 	}
 	return v
 }
@@ -154,7 +154,7 @@ func (v *validator) hasItems() *validator {
 		return v
 	}
 	if len(v.strArr) == 0 {
-		v.err = fmt.Errorf(`"%s" can't be empty`, v.name)
+		v.err = fmt.Errorf(`'%s' should contain at least one item`, v.name)
 	}
 	return v
 }
@@ -168,7 +168,7 @@ func (v *validator) hasUniqueItems() *validator {
 		m[s] = true
 	}
 	if len(m) != len(v.strArr) {
-		v.err = fmt.Errorf(`"%s" contains redundant values %s`, v.name, v.strArr)
+		v.err = fmt.Errorf(`'%s' contains redundant values '%s'`, v.name, v.strArr)
 	}
 	return v
 }


### PR DESCRIPTION
- Use real env variable names instead of internal variables in errors
- Fix `make run` target for missing environment variables