### PR TITLE
bump golic v0.5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           version: v1.32
       - name: golic
         run: |
-          go install github.com/AbsaOSS/golic@v0.4.7
+          go install github.com/AbsaOSS/golic@v0.5.0
           golic inject --dry -x -t apache2
       - name: go test
         run: go test ./...

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CLUSTER_GSLB2_HELM_ARGS ?= --set k8gb.clusterGeoTag='us' --set k8gb.extGslbClust
 LOG_FORMAT ?= simple
 LOG_LEVEL ?= debug
 CONTROLLER_GEN_VERSION  ?= v0.4.1
-GOLIC_VERSION  ?= v0.4.7
+GOLIC_VERSION  ?= v0.5.0
 POD_NAMESPACE ?= k8gb
 CLUSTER_GEO_TAG ?= eu
 EXT_GSLB_CLUSTERS_GEO_TAGS ?= us


### PR DESCRIPTION
fix message order in CI report

![Screenshot 2021-03-28 at 16 00 08](https://user-images.githubusercontent.com/7195836/112754920-acd3b780-8fde-11eb-8bf5-fed2990b4b77.png)

to

![Screenshot 2021-03-28 at 16 00 40](https://user-images.githubusercontent.com/7195836/112754937-c117b480-8fde-11eb-8ab5-f9dacb802898.png)
