### PR TITLE
Serve specific zone by CoreDNS

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -10,7 +10,7 @@ k8gb:
   # image tag defaults to Chart.AppVersion, see Chart.yaml
   # but can be overrided with imageTag key
   # imageTag:
-  dnsZone: "cloud.example.com" # dnsZone controlled by gslb
+  dnsZone: &dnsZone "cloud.example.com" # dnsZone controlled by gslb
   edgeDNSZone: "example.com" # main zone which would contain gslb zone to delegate
   edgeDNSServer: "1.1.1.1" # use this DNS server as a main resolver to enable cross k8gb DNS based communication
   clusterGeoTag: "eu" # used for places where we need to distinguish between differnet Gslb instances
@@ -61,7 +61,7 @@ coredns:
     - name: forward
       parameters: . /etc/resolv.conf
     - name: k8s_crd
-      parameters: .
+      parameters: *dnsZone
       configBlock: |-
         resources DNSEndpoint
         filter k8gb.absa.oss/dnstype=local


### PR DESCRIPTION
Serving . could lead into long resolves. Especially while service A
record only and alpine based workloads do both AAAA and A queries.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>