### PR TITLE
Extend Gslb CRD with additionalPrinterColumns

### DIFF
--- a/api/v1beta1/gslb_types.go
+++ b/api/v1beta1/gslb_types.go
@@ -59,6 +59,8 @@ type GslbStatus struct {
 // +kubebuilder:subresource:status
 
 // Gslb is the Schema for the gslbs API
+// +kubebuilder:printcolumn:name="strategy",type=string,JSONPath=`.spec.strategy.type`
+// +kubebuilder:printcolumn:name="geoTag",type=string,JSONPath=`.status.geoTag`
 type Gslb struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/chart/k8gb/templates/crds/k8gb.absa.oss_gslbs.yaml
+++ b/chart/k8gb/templates/crds/k8gb.absa.oss_gslbs.yaml
@@ -16,7 +16,14 @@ spec:
     singular: gslb
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.strategy.type
+      name: strategy
+      type: string
+    - jsonPath: .status.geoTag
+      name: geoTag
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Gslb is the Schema for the gslbs API
@@ -98,8 +105,6 @@ spec:
                         under a specified host to the related backend services. Incoming
                         requests are first evaluated for a host match, then routed
                         to the backend associated with the matching IngressRuleValue.
-                      required:
-                      - "http"
                       properties:
                         host:
                           description: "Host is the fully qualified domain name of
@@ -225,6 +230,8 @@ spec:
                           required:
                           - paths
                           type: object
+                      required:
+                      - http
                       type: object
                     type: array
                   tls:


### PR DESCRIPTION
Use https://book.kubebuilder.io/reference/generating-crd.html#additional-printer-columns
to add `additionalPrinterColumns` exposing strategy and geoTag of Gslb CR

From the user perspective it looks like
```sh
kubectl -n test-gslb get gslb
NAME                 STRATEGY     GEOTAG
test-gslb            roundRobin   eu-west-1
test-gslb-failover   failover     eu-west-1
```

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>