### PR TITLE
Upgrade testing

### DIFF
--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -1,4 +1,4 @@
-name: Terratest
+name: Upgrade Testing
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - '.spelling'
 
 jobs:
-  terratest:
+  upgrade-testing:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
@@ -40,8 +40,11 @@ jobs:
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
-      - name: K8GB deployment
-        run: make deploy-candidate
+      - name: K8GB deploy stable
+        run: make deploy-stable
+
+      - name: K8GB deploy-candidate-with-helm
+        run: make deploy-candidate-with-helm
 
       - name: Terratest
         run: make terratest


### PR DESCRIPTION
Upgrade testing workflow is executed per each push

 - deploy recent k8gb version to k3d cluster
 - build docker from branch
 - helm bumps k8gb in k3d cluster
 - run terratests

I had to add new targets to Makefile and because of code repetition I made necessary refactoring

related to #349