### PR TITLE
Fix possible host name clash in tests

### DIFF
--- a/terratest/examples/broken-gslb-no-http.yaml
+++ b/terratest/examples/broken-gslb-no-http.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ingress:
     rules:
-      - host: terratest-failover.cloud.example.com
+      - host: broken-no-http.cloud.example.com
   strategy:
     type: failover
     primaryGeoTag: eu

--- a/terratest/examples/broken-gslb.yaml
+++ b/terratest/examples/broken-gslb.yaml
@@ -1,11 +1,11 @@
 apiVersion: k8gb.absa.oss/v1beta1
 kind: Gslb
 metadata:
-  name: broken-test-gslb1
+  name: broken-test-gslb2
 spec:
   ingress:
     rules:
-      - host: terratest-failover.cloud.example.com
+      - host: terratest-broken.cloud.example.com
         https:
           paths:
           - backend:

--- a/terratest/examples/failover-lifecycle.yaml
+++ b/terratest/examples/failover-lifecycle.yaml
@@ -1,11 +1,11 @@
 apiVersion: k8gb.absa.oss/v1beta1
 kind: Gslb
 metadata:
-  name: test-gslb-failover-simple
+  name: test-gslb-lifecycle
 spec:
   ingress:
     rules:
-      - host: terratest-failover.cloud.example.com
+      - host: lifecycle.cloud.example.com
         http:
           paths:
           - backend:

--- a/terratest/test/k8gb_lifecycle_test.go
+++ b/terratest/test/k8gb_lifecycle_test.go
@@ -100,7 +100,7 @@ func TestK8gbRepeatedlyRecreatedFromIngress(t *testing.T) {
 func TestK8gbSpecKeepsStableAfterIngressUpdates(t *testing.T) {
 	t.Parallel()
 	// name of ingress and gslb
-	const name = "test-gslb-failover-simple"
+	const name = "test-gslb-lifecycle"
 
 	assertStrategy := func(t *testing.T, options *k8s.KubectlOptions) {
 		assertGslbSpec(t, options, name, "spec.strategy.splitBrainThresholdSeconds", "600")
@@ -109,7 +109,7 @@ func TestK8gbSpecKeepsStableAfterIngressUpdates(t *testing.T) {
 		assertGslbSpec(t, options, name, "spec.strategy.type", "failover")
 	}
 
-	kubeResourcePath, err := filepath.Abs("../examples/failover-spec.yaml")
+	kubeResourcePath, err := filepath.Abs("../examples/failover-lifecycle.yaml")
 	ingressResourcePath, err := filepath.Abs("../examples/ingress-annotation-failover.yaml")
 	require.NoError(t, err)
 	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique


### PR DESCRIPTION
Since tests are running in parralel, we should keep hostnames unique, to
avoid possible name clash from parralel tests.