### PR TITLE
FIX: race condition detected

### DIFF
--- a/terratest/test/k8gb_lifecycle_test.go
+++ b/terratest/test/k8gb_lifecycle_test.go
@@ -79,9 +79,7 @@ func TestK8gbRepeatedlyRecreatedFromIngress(t *testing.T) {
 
 	k8s.KubectlDelete(t, options, ingressResourcePath)
 
-	err = k8s.RunKubectlE(t, options, "delete", "gslb", name)
-
-	require.NoError(t, err)
+	assertGslbDeleted(t, options, ingress.Name)
 
 	// recreate ingress
 	k8s.KubectlApply(t, options, ingressResourcePath)


### PR DESCRIPTION
terratests failed sometimes

 - https://github.com/AbsaOSS/k8gb/runs/2298208578?check_suite_focus=true#step:6:196
 - https://github.com/AbsaOSS/k8gb/runs/2296105748?check_suite_focus=true#step:6:2248

The reason was that GSLB was deleted, although it was already removed by removing ingress. Depending on system performance, sometimes it passed, sometimes not. 