### PR TITLE
k8gb playground documentation, update A records for one agent

### DIFF
--- a/docs/local.md
+++ b/docs/local.md
@@ -65,16 +65,12 @@ As expected result you should see **eight A records** divided between nodes of b
 ...
 ...
 ;; ANSWER SECTION:
-localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.3
-localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.4
-localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.2
-localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.5
+localtargets-roundrobin.cloud.example.com. 30 IN A 172.16.0.3
+localtargets-roundrobin.cloud.example.com. 30 IN A 172.16.0.2
 ...
 ...
-localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.8
-localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.6
-localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.7
-localtargets-roundrobin.cloud.example.com. 30 IN A    172.16.0.9
+localtargets-roundrobin.cloud.example.com. 30 IN A 172.16.0.5
+localtargets-roundrobin.cloud.example.com. 30 IN A 172.16.0.4
 ```
 Both clusters have [podinfo](https://github.com/stefanprodan/podinfo) installed on the top.
 Run following command and check if you get two json responses.


### PR DESCRIPTION
Local playground is now running against one agent (#355,  [Makefile:310](https://github.com/AbsaOSS/k8gb/pull/355/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R310)) instead of three.
This PR fixes local playground documentation