### PR TITLE
Service CoreDNS Corefile by k8gb chart

### DIFF
--- a/chart/k8gb/Chart.lock
+++ b/chart/k8gb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: coredns
-  repository: https://coredns.github.io/helm
-  version: 1.14.0
-digest: sha256:3a6b4ca5f4e2be5a9d5c65320b975001f14a02a7eb258f922e68a9f37013e4db
-generated: "2021-02-05T20:59:23.594399+01:00"
+  repository: https://absaoss.github.io/coredns-helm
+  version: 1.15.1
+digest: sha256:db2e8003678cc6b10d8087c660fdea07c5ce0d0737b9ac974c5debd3553bfa8b
+generated: "2021-04-13T16:57:39.773609+02:00"

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -7,8 +7,8 @@ appVersion: v0.7.7
 
 dependencies:
   - name: coredns
-    repository: https://coredns.github.io/helm
-    version: 1.15.0
+    repository: https://absaoss.github.io/coredns-helm
+    version: 1.15.1
 
 home: https://www.k8gb.io/
 sources:

--- a/chart/k8gb/templates/coredns-cm.yaml
+++ b/chart/k8gb/templates/coredns-cm.yaml
@@ -1,0 +1,20 @@
+kind: ConfigMap
+metadata:
+  labels:
+{{ include "chart.labels" . | indent 4  }}
+  name: {{ .Release.Name }}-coredns
+apiVersion: v1
+data:
+  Corefile: |-
+    {{ .Values.k8gb.dnsZone }}:53 {
+        errors
+        health
+        ready
+        loadbalance round_robin
+        prometheus 0.0.0.0:9153
+        forward . /etc/resolv.conf
+        k8s_crd {
+            resources DNSEndpoint
+            filter k8gb.absa.oss/dnstype=local
+        }
+    }

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -36,35 +36,14 @@ externaldns:
 
 coredns:
   isClusterService: false
+  deployment:
+    skipConfig: true
   image:
     repository: absaoss/k8s_crd
     tag: "v0.0.2"
   serviceAccount:
     create: true
     name: coredns
-  servers:
-  - zones:
-    - zone: .
-    port: 53
-    plugins:
-    - name: log
-    - name: errors
-    # Serves a /health endpoint on :8080, required for livenessProbe
-    - name: health
-    # Serves a /ready endpoint on :8181, required for readinessProbe
-    - name: ready
-    - name: loadbalance
-      parameters: round_robin
-    # Serves a /metrics endpoint on :9153, required for serviceMonitor
-    - name: prometheus
-      parameters: 0.0.0.0:9153
-    - name: forward
-      parameters: . /etc/resolv.conf
-    - name: k8s_crd
-      parameters: .
-      configBlock: |-
-        resources DNSEndpoint
-        filter k8gb.absa.oss/dnstype=local
 
 infoblox:
   enabled: false


### PR DESCRIPTION
In order to propogate dnsZone into CoreDNS Corefile we need to service
configmap ourself and instruct CoreDNS chart to skip config creation.
This is done by skipConfig: true option.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>