### PR TITLE
FIX: Annotate and Label existing DNSEndpoints

### DIFF
--- a/controllers/providers/assistant/gslb.go
+++ b/controllers/providers/assistant/gslb.go
@@ -149,8 +149,10 @@ func (r *GslbLoggerAssistant) SaveDNSEndpoint(namespace string, i *externaldns.D
 		return err
 	}
 
-	// Update existing object with new spec
+	// Update existing object with new spec, labels and annotations
 	found.Spec = i.Spec
+	found.ObjectMeta.Annotations = i.ObjectMeta.Annotations
+	found.ObjectMeta.Labels = i.ObjectMeta.Labels
 	err = r.client.Update(context.TODO(), found)
 
 	if err != nil {


### PR DESCRIPTION
When upgrading from 0.7.5 to 0.7.6 new generated objectmeta wasn't
concidered during DNSEndpoint reconcilation. Fix this by respecting
computed Labels and Annotations while reconciling DNSEndpoint.

fixes https://github.com/AbsaOSS/k8gb/issues/324

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>