### PR TITLE
bump k3d-action to v1.4.0

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -19,7 +19,7 @@ jobs:
           destination-repo: absaoss/k8gb
           destination-branch: gh-pages
       - name: Create single node k3s cluster
-        uses: AbsaOSS/k3d-action@v1.3.1
+        uses: AbsaOSS/k3d-action@v1.4.0
         with:
           cluster-name: "test-gslb1"
           use-default-registry: false
@@ -30,6 +30,7 @@ jobs:
             --agents 1
             --no-lb
             --network k3d-action-bridge-network
+            --image docker.io/rancher/k3s:v1.20.5-k3s1
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
       - name: Smoke test helm installation
         run: |

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -15,13 +15,13 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Create 1st k3s Cluster
-        uses: AbsaOSS/k3d-action@v1.3.1
+        uses: AbsaOSS/k3d-action@v1.4.0
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
 
       - name: Create 2nd k3s Cluster
-        uses: AbsaOSS/k3d-action@v1.3.1
+        uses: AbsaOSS/k3d-action@v1.4.0
         with:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -15,13 +15,13 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Create 1st k3s Cluster
-        uses: AbsaOSS/k3d-action@v1.3.1
+        uses: AbsaOSS/k3d-action@v1.4.0
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
 
       - name: Create 2nd k3s Cluster
-        uses: AbsaOSS/k3d-action@v1.3.1
+        uses: AbsaOSS/k3d-action@v1.4.0
         with:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -1,6 +1,7 @@
 apiVersion: k3d.io/v1alpha2
 kind: Simple
 name: test-gslb1
+image: docker.io/rancher/k3s:v1.20.5-k3s1
 agents: 1
 network: k3d-action-bridge-network
 ports:

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -1,6 +1,7 @@
 apiVersion: k3d.io/v1alpha2
 kind: Simple
 name: test-gslb2
+image: docker.io/rancher/k3s:v1.20.5-k3s1
 agents: 1
 network: k3d-action-bridge-network
 ports:


### PR DESCRIPTION
For more details, see: https://github.com/AbsaOSS/k3d-action/releases/tag/v1.4.0

 - Bump k3d-action to v 1.4.0
   - bumps k3d v4.2.0 -> v4.4.1
   - default docker.io/rancher/k3s:v1.20.4-k3s1 -> is configured manually and upgraded to docker.io/rancher/k3s:v1.20.5-k3s1
 