### PR TITLE
[Fix] Validate when multiple providers are defined

### DIFF
--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -60,17 +60,19 @@ func (f LogFormat) String() string {
 }
 
 // EdgeDNSType specifies to which edge DNS is k8gb connecting
-type EdgeDNSType int
+type EdgeDNSType string
 
 const (
 	// DNSTypeNoEdgeDNS is default DNSType. Is used during integration testing when no edgeDNS provider exists
-	DNSTypeNoEdgeDNS EdgeDNSType = 1 << iota
+	DNSTypeNoEdgeDNS EdgeDNSType = "NoEdgeDNS"
 	// DNSTypeInfoblox type
-	DNSTypeInfoblox
+	DNSTypeInfoblox EdgeDNSType = "Infoblox"
 	// DNSTypeRoute53 type
-	DNSTypeRoute53
+	DNSTypeRoute53 EdgeDNSType = "Route53"
 	// DNSTypeNS1 type
-	DNSTypeNS1
+	DNSTypeNS1 EdgeDNSType = "NS1"
+	// DNSTypeMultipleProviders type
+	DNSTypeMultipleProviders EdgeDNSType = "MultipleProviders"
 )
 
 // Log configuration
@@ -131,14 +133,14 @@ type Config struct {
 	Infoblox Infoblox
 	// Override the behavior of GSLB in the test environments
 	Override Override
-	// route53Enabled hidden. EdgeDNSType defines all enabled Enabled types
-	route53Enabled bool
-	// ns1Enabled flag
-	ns1Enabled bool
 	// CoreDNSExposed flag
 	CoreDNSExposed bool
 	// Log configuration
 	Log Log
+	// route53Enabled hidden. EdgeDNSType defines all enabled Enabled types
+	route53Enabled bool
+	// ns1Enabled flag
+	ns1Enabled bool
 }
 
 // DependencyResolver resolves configuration for GSLB

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -1222,8 +1222,8 @@ func provideSettings(t *testing.T, expected depresolver.Config) (settings testSe
 func cleanup() {
 	for _, s := range []string{depresolver.ReconcileRequeueSecondsKey, depresolver.ClusterGeoTagKey, depresolver.ExtClustersGeoTagsKey,
 		depresolver.EdgeDNSZoneKey, depresolver.DNSZoneKey, depresolver.EdgeDNSServerKey, depresolver.K8gbNamespaceKey,
-		depresolver.Route53EnabledKey, depresolver.InfobloxGridHostKey, depresolver.InfobloxVersionKey, depresolver.InfobloxPortKey,
-		depresolver.InfobloxUsernameKey, depresolver.InfobloxPasswordKey, depresolver.InfobloxHTTPRequestTimeoutKey,
+		depresolver.Route53EnabledKey, depresolver.NS1EnabledKey, depresolver.InfobloxGridHostKey, depresolver.InfobloxVersionKey,
+		depresolver.InfobloxPortKey, depresolver.InfobloxUsernameKey, depresolver.InfobloxPasswordKey, depresolver.InfobloxHTTPRequestTimeoutKey,
 		depresolver.InfobloxHTTPPoolConnectionsKey, depresolver.OverrideWithFakeDNSKey, depresolver.OverrideFakeInfobloxKey,
 		depresolver.LogLevelKey, depresolver.LogFormatKey, depresolver.LogNoColorKey} {
 		if os.Unsetenv(s) != nil {
@@ -1241,6 +1241,7 @@ func configureEnvVar(config depresolver.Config) {
 	_ = os.Setenv(depresolver.DNSZoneKey, config.DNSZone)
 	_ = os.Setenv(depresolver.K8gbNamespaceKey, config.K8gbNamespace)
 	_ = os.Setenv(depresolver.Route53EnabledKey, strconv.FormatBool(config.EdgeDNSType == depresolver.DNSTypeRoute53))
+	_ = os.Setenv(depresolver.NS1EnabledKey, strconv.FormatBool(config.EdgeDNSType == depresolver.DNSTypeNS1))
 	_ = os.Setenv(depresolver.InfobloxGridHostKey, config.Infoblox.Host)
 	_ = os.Setenv(depresolver.InfobloxVersionKey, config.Infoblox.Version)
 	_ = os.Setenv(depresolver.InfobloxPortKey, strconv.Itoa(config.Infoblox.Port))

--- a/controllers/providers/dns/factory.go
+++ b/controllers/providers/dns/factory.go
@@ -42,17 +42,15 @@ func NewDNSProviderFactory(client client.Client, config depresolver.Config) (f *
 	return
 }
 
-func (f *ProviderFactory) Provider() (provider IDnsProvider) {
+func (f *ProviderFactory) Provider() IDnsProvider {
 	a := assistant.NewGslbAssistant(f.client, f.config.K8gbNamespace, f.config.EdgeDNSServer)
 	switch f.config.EdgeDNSType {
 	case depresolver.DNSTypeNS1:
-		provider = NewExternalDNS(externalDNSTypeNS1, f.config, a)
+		return NewExternalDNS(externalDNSTypeNS1, f.config, a)
 	case depresolver.DNSTypeRoute53:
-		provider = NewExternalDNS(externalDNSTypeRoute53, f.config, a)
+		return NewExternalDNS(externalDNSTypeRoute53, f.config, a)
 	case depresolver.DNSTypeInfoblox:
-		provider = NewInfobloxDNS(f.config, a)
-	case depresolver.DNSTypeNoEdgeDNS:
-		provider = NewEmptyDNS(f.config, a)
+		return NewInfobloxDNS(f.config, a)
 	}
-	return
+	return NewEmptyDNS(f.config, a)
 }


### PR DESCRIPTION
resolves #448

 - `controller_test.go` was missing NS1EnabledKey in the cleanup() and configureEnvVar(), added
 
 - rewrite `depresolver.getEdgeDNSType()`, the function now coud return one more DNSType: `DNSTypeError`.
 `DNSTypeError` indicates depresolver found more than one provider. `DNSTypeError` generates validation error on k8gb startup. 
 
  - `DNSTypeNoEdgeDNS` is returned when no provider is not recognised. This state passes validation; @ytsarev, is that expected behavior ? 
  
 - functionality covered  by depresolver tests.

Signed-off-by: kuritka <kuritka@gmail.com>