### PR TITLE
Terratest timeout 15 min, parallel 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ test-failover:
 # executes terra-tests
 .PHONY: terratest
 terratest: # Run terratest suite
-	cd terratest/test/ && go mod download && go test -v
+	cd terratest/test/ && go mod download && go test -v -timeout 15m -parallel=12
 
 .PHONY: version
 version:


### PR DESCRIPTION
It happened that long running test `TestK8gbBasicRoundRobinExample` didn't finish [during 10 minutes](https://github.com/AbsaOSS/k8gb/pull/450/checks?check_run_id=2380389415#step:7:3939) terratest run.
We are running tests in Parallel. The maximum number of tests to run simultaneously is by default set to the value of GOMAXPROCS (the number of CPU's visible to the program startup). That's why tests are running in smaller parallel chunks (waves).

From what I see in the logs, `TestK8gbBasicRoundRobinExample` started in 4th minute of terratest (n-th wave) and  was not fast enough to scale-up GSLB in the last subtest(subtests are sequential in the scope of test), The `TestK8gbBasicRoundRobinExample` timeouted see: [text log](https://pipelines.actions.githubusercontent.com/fdhui6E3r0qyGjKGI7JL2oBgou8JslTAp47a0VPoFebyddvI6q/_apis/pipelines/1/runs/4893/signedlogcontent/3?urlExpires=2021-04-19T12%3A28%3A36.7191880Z&urlSigningMethod=HMACV1&urlSignature=Dv0kIy48JHrB0wGt8ueUp90%2FtisqMuQ8w4QHV2dr5b4%3D)

I saw this behavior first time.

 - Regarding documentation I extended [timeout to 12m](https://terratest.gruntwork.io/docs/testing-best-practices/timeouts-and-logging/).
 - I extended number of parallel process to 12, so test execution doesn't run in waves now. 
 I shorten terratest run from usual 9+ to 6+ minutes 

![Screenshot 2021-04-19 at 17 15 54](https://user-images.githubusercontent.com/7195836/115260285-e9548800-a132-11eb-8c5f-70657ae30241.png)
_10 minutes limit can exceed quickly !!_ 

![Screenshot 2021-04-19 at 17 15 06](https://user-images.githubusercontent.com/7195836/115260166-cb872300-a132-11eb-8f72-2d102f09e3ba.png)


Signed-off-by: kuritka <kuritka@gmail.com>