### PR TITLE
golint, check capitalized error strings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,3 +20,5 @@ run:
 linters-settings:
   lll:
     line-length: 150
+  golint:
+    min-confidence: 0


### PR DESCRIPTION
To check capitalized error strings I'm adding golint `min-confidence=0`
https://github.com/golang/go/wiki/CodeReviewComments#error-strings

As you can see, `min-confidence=0` didn't found any issues on our master branch 💯 .

*Golint makes suggestions for many of the mechanically checkable items listed in
[Effective Go](https://golang.org/doc/effective_go) and the [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments) wiki page.*

Signed-off-by: kuritka <kuritka@gmail.com>