### PR TITLE
Flag enabling SplitBrain

### DIFF
--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -121,3 +121,5 @@ spec:
               value: {{ quote .Values.k8gb.log.level }}
             - name: NO_COLOR
               value: "true"
+            - name: SPLIT_BRAIN_CHECK
+              value: {{ quote .Values.k8gb.splitBrainCheck }}

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -25,6 +25,7 @@ k8gb:
   log:
     format: simple # log format (simple,json)
     level: info # log level (panic,fatal,error,warn,info,debug,trace)
+  splitBrainCheck: false
 
 externaldns:
   image: k8s.gcr.io/external-dns/external-dns:v0.7.5

--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -141,6 +141,8 @@ type Config struct {
 	route53Enabled bool
 	// ns1Enabled flag
 	ns1Enabled bool
+	// SplitBrainCheck flag decides whether split brain TXT records will be stored in edge DNS
+	SplitBrainCheck bool
 }
 
 // DependencyResolver resolves configuration for GSLB

--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -50,6 +50,7 @@ const (
 	LogLevelKey                    = "LOG_LEVEL"
 	LogFormatKey                   = "LOG_FORMAT"
 	LogNoColorKey                  = "NO_COLOR"
+	SplitBrainCheckKey             = "SPLIT_BRAIN_CHECK"
 )
 
 // ResolveOperatorConfig executes once. It reads operator's configuration
@@ -80,6 +81,7 @@ func (dr *DependencyResolver) ResolveOperatorConfig() (*Config, error) {
 		dr.config.Log.Level, _ = zerolog.ParseLevel(strings.ToLower(env.GetEnvAsStringOrFallback(LogLevelKey, zerolog.InfoLevel.String())))
 		dr.config.Log.Format = parseLogOutputFormat(strings.ToLower(env.GetEnvAsStringOrFallback(LogFormatKey, SimpleFormat.String())))
 		dr.config.Log.NoColor = env.GetEnvAsBoolOrFallback(LogNoColorKey, false)
+		dr.config.SplitBrainCheck = env.GetEnvAsBoolOrFallback(SplitBrainCheckKey, false)
 		dr.config.EdgeDNSType, recognizedDNSTypes = getEdgeDNSType(dr.config)
 		dr.errorConfig = dr.validateConfig(dr.config, recognizedDNSTypes)
 	})

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -1225,7 +1225,7 @@ func cleanup() {
 		depresolver.Route53EnabledKey, depresolver.NS1EnabledKey, depresolver.InfobloxGridHostKey, depresolver.InfobloxVersionKey,
 		depresolver.InfobloxPortKey, depresolver.InfobloxUsernameKey, depresolver.InfobloxPasswordKey, depresolver.InfobloxHTTPRequestTimeoutKey,
 		depresolver.InfobloxHTTPPoolConnectionsKey, depresolver.OverrideWithFakeDNSKey, depresolver.OverrideFakeInfobloxKey,
-		depresolver.LogLevelKey, depresolver.LogFormatKey, depresolver.LogNoColorKey} {
+		depresolver.LogLevelKey, depresolver.LogFormatKey, depresolver.LogNoColorKey, depresolver.SplitBrainCheckKey} {
 		if os.Unsetenv(s) != nil {
 			panic(fmt.Errorf("cleanup %s", s))
 		}
@@ -1254,4 +1254,5 @@ func configureEnvVar(config depresolver.Config) {
 	_ = os.Setenv(depresolver.LogLevelKey, config.Log.Level.String())
 	_ = os.Setenv(depresolver.LogFormatKey, config.Log.Format.String())
 	_ = os.Setenv(depresolver.LogNoColorKey, strconv.FormatBool(config.Log.NoColor))
+	_ = os.Setenv(depresolver.SplitBrainCheckKey, strconv.FormatBool(config.SplitBrainCheck))
 }

--- a/controllers/providers/dns/common.go
+++ b/controllers/providers/dns/common.go
@@ -32,19 +32,25 @@ func nsServerName(config depresolver.Config) string {
 }
 
 func nsServerNameExt(config depresolver.Config) (extNSServers []string) {
-	dnsZoneIntoNS := strings.ReplaceAll(config.DNSZone, ".", "-")
-	extNSServers = []string{}
+	extNSServers = make([]string, 0)
 	for _, clusterGeoTag := range config.ExtClustersGeoTags {
-
-		extNSServers = append(extNSServers,
-			fmt.Sprintf("gslb-ns-%s-%s.%s", dnsZoneIntoNS, clusterGeoTag, config.EdgeDNSZone))
+		extNSServers = append(extNSServers, getNSServerName(clusterGeoTag, config.DNSZone, config.EdgeDNSZone))
 	}
 	return extNSServers
 }
 
 func getExternalClusterHeartbeatFQDNs(gslb *k8gbv1beta1.Gslb, config depresolver.Config) (extGslbClusters []string) {
 	for _, geoTag := range config.ExtClustersGeoTags {
-		extGslbClusters = append(extGslbClusters, fmt.Sprintf("%s-heartbeat-%s.%s", gslb.Name, geoTag, config.EdgeDNSZone))
+		extGslbClusters = append(extGslbClusters, getExternalClusterHeartbeatFQDN(gslb, geoTag, config.EdgeDNSZone))
 	}
 	return
+}
+
+func getNSServerName(geoTag, dnsZone, edgeDNSZone string) string {
+	dnsZoneIntoNS := strings.ReplaceAll(dnsZone, ".", "-")
+	return fmt.Sprintf("gslb-ns-%s-%s.%s", dnsZoneIntoNS, geoTag, edgeDNSZone)
+}
+
+func getExternalClusterHeartbeatFQDN(gslb *k8gbv1beta1.Gslb, geoTag, edgeDNSZone string) string {
+	return fmt.Sprintf("%s-heartbeat-%s.%s", gslb.Name, geoTag, edgeDNSZone)
 }


### PR DESCRIPTION
**SplitBrainCheck flag**; If false (default) splitBrain is disabled, no metter what EdgeDNSType you use.
To enable SplitBrain, set `SPLIT_BRAIN_CHECK` to true

- I added new field to depresolver Config (SplitBrainCheck) and introduced new env var `SPLIT_BRAIN_CHECK`.
- I updated infoblox provider to skip TXT interractions when !SplitBrainCheck
- Me & k0da made e2e tests against test clusters
- Fix heartbeat issue


Signed-off-by: kuritka <kuritka@gmail.com>